### PR TITLE
feat(test-privacy-boundary): separate public tests from private persona data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,13 @@ jobs:
   test:
     name: Lint + typecheck + test
     runs-on: ubuntu-latest
+    env:
+      # Belt-and-suspenders: tests/conftest.py also sets this via
+      # os.environ.setdefault at module-top, but declaring it at job
+      # level means any future static-analysis step that inadvertently
+      # loads persona configs will see the fixture root, not an empty
+      # submodule mount. See docs/gotchas.md G6 (IR-C4).
+      ASSISTANT_PERSONAS_DIR: tests/fixtures/personas
     steps:
       - name: Checkout (public repo only — persona submodules are private)
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,10 @@ jobs:
       - name: Sync dependencies
         run: uv sync --all-extras --dev
 
-      # Submodule is private and CI lacks credentials. We ship a
-      # self-contained fixture under tests/fixtures/personas/personal/ and
-      # overlay it onto the submodule mount point so tests can discover and
-      # load the personal persona. See docs/gotchas.md G2.
-      - name: Populate personas/personal from test fixture
-        run: |
-          mkdir -p personas/personal
-          cp -R tests/fixtures/personas/personal/. personas/personal/
+      # Public tests read from tests/fixtures/personas/ directly (via the
+      # ASSISTANT_PERSONAS_DIR env var set in tests/conftest.py), so no
+      # populate step is needed. See docs/gotchas.md G6 and the
+      # test-privacy-boundary OpenSpec change for the full design.
 
       - name: Ruff
         run: uv run ruff check .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,16 @@ Common commands:
 - Python 3.12, type hints, Ruff, pytest
 - Extension code in public repo, activation config in private repos
 - Each persona gets its own database (ParadeDB Postgres) — wired in P3
-- Tests run against real `roles/` + `personas/` directories (no filesystem
-  mocking); see `tests/conftest.py`
+- Tests run against the in-repo `tests/fixtures/personas/` (public tests)
+  or the persona's own submodule (persona-specific tests), never against
+  the real `personas/<name>/` submodule from public code; see
+  `tests/conftest.py`.
+- Public tests use fixtures only (`tests/fixtures/personas/`);
+  persona-specific tests live in each persona's private submodule and
+  must be self-contained (no imports from `src/assistant/*`); the
+  two-layer privacy guard in `tests/conftest.py` +
+  `tests/_privacy_guard_plugin.py` enforces this at collection time
+  (substring scan) and at runtime (FS I/O patching).
 
 ## Known gotchas
 

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -234,6 +234,17 @@ literals out of test source entirely — use dynamic needle construction
 (`tuple(f"personas/{n}/" for n in FORBIDDEN_PATH_NAMES)`) in any file
 that legitimately needs to reference the deny-list as data.
 
+**The `ASSISTANT_PERSONAS_DIR` env var.** `tests/conftest.py` sets this
+via `os.environ.setdefault` so every in-process `PersonaRegistry` /
+`RoleRegistry` (including the one `cli.py` builds when tests invoke
+`assistant -p personal`) honors the fixture root. CI also sets it at
+the job level as defense-in-depth. Precedence is
+`explicit constructor arg > env var > Path("personas") default` — this
+contract is locked by `tests/test_env_var_contract.py`, which every
+change to `PersonaRegistry`/`RoleRegistry` constructors must keep green.
+The env var is an implementation detail enabling the repoint, not a
+public configuration surface; production callers should leave it unset.
+
 ---
 
 ## G7. Submodule test standalone mode silent-skip

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -147,3 +147,133 @@ When a user requests X, the system SHALL do Y.
 # OK:
 The system SHALL do Y when a user requests X.
 ```
+
+---
+
+## G6. Private-persona content leakage via public test assertions
+
+**Symptom**: One of:
+1. CI passes locally but private content (prompt strings, role-override
+   phrasing) appears verbatim in public test code, or shows up in `git log`
+   diffs against the public repo.
+2. A test fails at collection with `_PrivacyBoundaryViolation` (subclass
+   of `pytest.UsageError`) naming a forbidden `personas/<name>/` path.
+3. CI passes but the fixture and the real submodule have diverged and
+   nobody noticed until local runs surface a shape mismatch.
+
+**Root cause**: two failure classes, both caught by the two-layer guard:
+
+1. **Literal-path leak** — a public test file contains the substring
+   `personas/personal/` or `personas/work/` (in an assertion, a path
+   literal, or even a docstring comment). Layer 1's collection-time
+   substring scan (`tests/conftest.py`) catches this.
+2. **Constructed-path leak** — a test builds a forbidden path via join
+   idioms like `Path("personas") / name / "persona.yaml"` where `name`
+   comes from a variable, parameter, or env lookup. The substring scan
+   cannot see this (no literal appears in source). Layer 2's runtime FS
+   guard (`tests/_privacy_guard_plugin.py`) catches it by patching
+   `pathlib.Path.open`, `Path.read_text`, `Path.read_bytes`,
+   `builtins.open`, `os.open`, and `subprocess.Popen.__init__` — any
+   read or subprocess argv that resolves under `personas/<forbidden>/`
+   raises `_PrivacyBoundaryViolation` at the moment of call.
+
+Common upstream cause: `personas_dir` fixture in `tests/conftest.py` was
+(re-)pointed at `REPO_ROOT / "personas"` instead of
+`REPO_ROOT / "tests" / "fixtures" / "personas"`, so every consumer of
+the fixture now reads the real submodule.
+
+**Fix**:
+
+```python
+# tests/conftest.py — correct:
+@pytest.fixture
+def personas_dir() -> Path:
+    return REPO_ROOT / "tests" / "fixtures" / "personas"
+
+# tests/conftest.py — WRONG (resurrects the leak):
+@pytest.fixture
+def personas_dir() -> Path:
+    return REPO_ROOT / "personas"
+```
+
+- Rewrite assertions to use fixture-defined values (e.g. the
+  `FIXTURE_PERSONA_SENTINEL_v1` marker in the fixture prompt) rather than
+  strings lifted from the real submodule.
+- If a test genuinely needs to validate real submodule data, it does not
+  belong in the public `tests/` tree — relocate it to
+  `personas/<name>/tests/` as a self-contained test (no imports from
+  `src/assistant/*`, YAML parsed via `yaml.safe_load`). See D3/D4 in
+  `openspec/changes/test-privacy-boundary/design.md`.
+
+**How to detect**: run `uv run pytest tests/` from a clean checkout with
+the submodule deinitialized (`git submodule deinit -f personas/personal`).
+If the suite passes, the boundary is intact. If anything fails with a
+missing `personas/<name>/persona.yaml`, you have a leak. The wrapper
+`scripts/verify-public-tests-standalone.sh` automates this safely (uses
+`trap` to restore the submodule on exit).
+
+**Prevention**: the two-layer guard in `tests/conftest.py` +
+`tests/_privacy_guard_plugin.py` catches both literal and
+constructed-path leaks at collection/runtime, reading its deny-list
+(`FORBIDDEN_PATH_NAMES = ("personal", "work")`) from
+`tests/_privacy_guard_config.py`. The guard also covers `work` from day
+one even though `personas/work/` is not yet populated.
+
+**Known out-of-coverage surface** (per design R2 —
+`openspec/changes/test-privacy-boundary/design.md`): the runtime guard
+does NOT see (a) `mmap.mmap` on an already-opened file descriptor, (b)
+`ctypes`-based I/O bypassing the stdlib entirely, (c) `os.system` on
+Windows (it dispatches through `cmd.exe`, not `subprocess.Popen`), or
+(d) deliberately-split subprocess argv where the forbidden substring is
+reconstructed only after `execve` (e.g. `['sh', '-c', f'cat
+personas/{name}/x']` with `name` obtained from an env var read at
+subprocess time). These are outside the documented threat model
+(deliberate evasion, not accidental Copilot idiom). Layer 1's substring
+scan is the only defense for any of these patterns, so keep forbidden
+literals out of test source entirely — use dynamic needle construction
+(`tuple(f"personas/{n}/" for n in FORBIDDEN_PATH_NAMES)`) in any file
+that legitimately needs to reference the deny-list as data.
+
+---
+
+## G7. Submodule test standalone mode silent-skip
+
+**Symptom**: A submodule maintainer runs
+`cd personas/personal && pytest tests/` in isolation (without a parent
+checkout), the suite reports green, and the maintainer pushes. Later, a
+full parent-checkout run fails: a role override in the submodule
+references a base role that does not exist in the parent `roles/`
+directory, breaking composition.
+
+**Root cause**: `personas/personal/tests/test_role_overrides.py` used to
+resolve the parent roles directory via
+`Path(__file__).resolve().parents[2] / "roles"`. When the submodule is
+checked out standalone (not inside a parent), that path does not exist,
+and an earlier draft silently skipped the existence check. Silent-skip
+converted a real invariant violation into a false green.
+
+**Fix**: the check now `pytest.fail`s by default with a message naming
+the required env var. Setting `ALLOW_STANDALONE_SUBMODULE_SKIP=1`
+converts the failure to an explicit `pytest.skip` with a loud message —
+an opt-in acknowledging "I know this run does not validate the cross-repo
+invariant":
+
+```bash
+# Default (strict): fails loudly if parent roles/ unreachable
+cd personas/personal && pytest tests/
+
+# Explicit opt-in for standalone runs (skip with loud message):
+ALLOW_STANDALONE_SUBMODULE_SKIP=1 pytest tests/
+```
+
+**How to detect**: if `pytest tests/` in the submodule reports
+`SKIPPED [1] test_role_overrides.py: parent roles/ not reachable...`
+**without** the env var set, the strict mode is broken — file a bug
+against the submodule. If the env var is set, that single skip line is
+expected and announces itself clearly.
+
+**Prevention**: default is strict; the env var is documented here (G7),
+in the submodule's own README, and in the failure message itself so
+maintainers always know the exact incantation to bypass. The parent-repo
+run never sets this env var, so the cross-repo invariant is exercised
+every time the full suite runs from a parent checkout.

--- a/openspec/changes/test-privacy-boundary/contracts/README.md
+++ b/openspec/changes/test-privacy-boundary/contracts/README.md
@@ -1,0 +1,21 @@
+# Contracts — test-privacy-boundary
+
+No contract sub-types apply to this change. Each was evaluated:
+
+| Sub-type | Applies? | Rationale |
+|----------|----------|-----------|
+| OpenAPI (`contracts/openapi/`) | No | Change does not add, modify, or remove HTTP endpoints. |
+| Database (`contracts/db/`) | No | Change does not add, modify, or remove database schemas or migrations. |
+| Events (`contracts/events/`) | No | Change does not add, modify, or remove event types or payloads. |
+| Generated types (`contracts/generated/`) | No | No upstream contract to generate from. |
+
+This change is scoped to **test infrastructure, CI configuration, and
+documentation**. The boundary between public and private test scopes is
+enforced by a `pytest_collection_modifyitems` hook in `tests/conftest.py`
+(code-level, in-repo) and by the submodule's own `pyproject.toml` + test
+suite (repo-boundary, self-contained). Neither produces an externally
+consumable interface that needs a machine-readable contract artifact.
+
+Consuming skills that iterate over `contracts/` should treat a directory
+containing only this `README.md` as "no contracts applicable" per the
+fallback convention in `/plan-feature` Step 7.

--- a/openspec/changes/test-privacy-boundary/design.md
+++ b/openspec/changes/test-privacy-boundary/design.md
@@ -6,19 +6,31 @@ The public repo contains persona-consuming test code; the private repo (the
 `personas/personal/` submodule) contains persona *data*. The current
 `tests/conftest.py` resolves `personas_dir` to `REPO_ROOT / "personas"`, which
 points at the submodule mount. Public tests can therefore read private data
-and encode private strings as assertions. This change repartitions testing
+and encode private content as assertions. This change repartitions testing
 along the existing privacy seam rather than introducing a new abstraction.
+
+Round 1 review surfaced that an earlier draft of this design relied on a
+`FORBIDDEN_CONTENT_STRINGS` deny-list. That approach was incoherent: the
+strings the public repo can enumerate are exactly the strings that already
+exist in the public fixture (e.g. `"Personal Persona Context"` lives in
+`tests/fixtures/personas/personal/prompt.md`), so a deny-list keyed on them
+would block legitimate fixture-based assertions while still missing any
+truly-private string the public repo cannot see. The design now drops the
+content-string approach entirely and treats **path-based enforcement as the
+sole authoritative signal**, with two enforcement layers (substring scan as
+collection-time advisory + runtime filesystem guard as authoritative).
 
 ## Goals
 
 - **G1**: Public tests must run to green without the private submodule being
   populated.
-- **G2**: Any attempt to introduce a reference to `personas/personal/` or
-  `personas/work/` (or private-content strings) from within public `tests/`
-  must fail at collection time, with a clear remediation message.
+- **G2**: Any attempt to introduce a path-based reference to
+  `personas/personal/` or `personas/work/` from public `tests/` must fail —
+  loudly, at collection time when the reference is a literal substring, and
+  at runtime when the reference is constructed via path-join idioms.
 - **G3**: The `personas/personal/` submodule must own its own test suite
-  that runs *without importing anything from `src/assistant/`*, so the
-  persona data is reusable by a non-Python harness.
+  that runs *without `assistant` being importable*, so the persona data is
+  reusable by a non-Python consumer.
 - **G4**: The CI workaround (commit `76a313e`) must be removed, eliminating
   the "keep fixture in sync with submodule" maintenance burden.
 
@@ -32,59 +44,80 @@ along the existing privacy seam rather than introducing a new abstraction.
   secret.
 - **NG3**: This change does not populate `personas/work/`. P6
   (`work-persona-config`) remains the home for that work.
+- **NG4**: The boundary guard scope is the public `tests/` tree only.
+  `openspec/changes/<id>/specs/*.md` and `docs/*.md` may name forbidden
+  paths or strings for documentation purposes — they are not collected by
+  pytest and not under the guard.
+- **NG5**: This change does not enumerate "private content strings". The
+  public repo cannot know what is private inside the submodule; trying to
+  list private strings is a category error. Path-based enforcement is the
+  full closure.
 
 ## Key decisions
 
-### D1: Collection-time guard, not runtime guard
+### D1: Two-layer guard — substring scan + runtime FS guard
 
-**Decision**: Enforcement runs as a `pytest_collection_modifyitems` hook that
-reads each collected test file's source text and refuses to continue if it
-contains a forbidden substring.
+**Decision**: Enforcement runs as **two layers** wired into pytest:
 
-**Why**: The guard must fail **before** any test body executes, so a developer
-who writes a leak locally gets immediate, unambiguous feedback. A runtime
-guard (e.g., patching `Path.open` to deny reads under `personas/`) would only
-fire during execution, producing confusing late failures and potentially
-missing never-run code paths.
+- **Layer 1 (advisory, collection-time)**: A
+  `pytest_collection_modifyitems` hook reads each collected test file's
+  source text and emits a clear failure if it contains a forbidden path
+  substring. Catches the obvious case quickly with a readable message
+  before any test body runs.
+- **Layer 2 (authoritative, runtime)**: A pytest plugin (registered via
+  `tests/_privacy_guard_plugin.py` and loaded via `pytest_plugins` in
+  `tests/conftest.py`) patches `pathlib.Path.open`, `pathlib.Path.read_text`,
+  `pathlib.Path.read_bytes`, and `builtins.open` for the duration of test
+  collection and execution. Any attempt to open a path that resolves under
+  `personas/<name>/` (where `<name>` is in `FORBIDDEN_PATH_NAMES`) raises
+  `_PrivacyBoundaryViolation`, which inherits from `pytest.UsageError`.
+  Allow-listed read paths under `tests/fixtures/` and `personas/_template/`
+  are permitted.
 
-**Trade-off**: Collection-time source inspection is coarse — it matches on
-substrings, not on AST-level semantics. A test that builds the forbidden path
-via string concatenation (`"personas/" + "personal"`) would slip past. We
-accept this because (a) the threat model is accidental leakage, not
-adversarial circumvention, and (b) if such a test were written, the *content
-string* deny-list (`"Personal Persona Context"` etc.) would catch its
-assertions anyway.
+**Why**: Layer 1 alone cannot stop the standard
+`Path("personas") / persona_name / "persona.yaml"` idiom — Copilot and
+hand-written code routinely build paths that way and produce no matching
+substring. Layer 2 catches *any* read attempt regardless of how the path
+was constructed, because all reads ultimately funnel through `Path.open` /
+`builtins.open`. Together they give fast feedback on the easy cases and
+real coverage on the hard ones.
 
-### D2: Deny-list is configured, not hardcoded
+**Trade-off**: Layer 2 monkey-patches `builtins.open`, which is invasive.
+Mitigation: the plugin only patches during pytest collection + run (not at
+import time of unrelated modules), and it explicitly allows reads outside
+the `personas/<name>/` namespace, so production code paths exercised by
+tests are unaffected. The plugin lives in a single file and is small enough
+to review in one sitting.
 
-**Decision**: The guard reads its path-prefix deny-list and private-content
-string deny-list from a constant near the top of `tests/conftest.py`:
+### D2: Path-based deny-list as module constants
+
+**Decision**: The guard's deny-list and allow-list live as module constants
+in `tests/_privacy_guard_config.py`:
 
 ```python
-FORBIDDEN_PATH_SUBSTRINGS = (
-    "personas/personal/",
-    "personas/work/",
-)
-FORBIDDEN_CONTENT_STRINGS = (
-    "Personal Persona Context",
-    "Personal Context Additions",
-)
-ALLOWED_PATH_SUBSTRINGS = (
-    "personas/_template/",
-    "tests/fixtures/",
-)
+FORBIDDEN_PATH_NAMES = ("personal", "work")
+ALLOWED_READ_PREFIXES = ("tests/fixtures/", "personas/_template/")
 ```
 
-**Why**: Keeps the rules one scroll away from any developer writing tests,
-and makes it trivial to extend when new persona names or private prompt
-phrases are introduced. Avoids pulling in a YAML/TOML config file for a
-three-tuple of constants.
+Both layers (substring scan and runtime FS guard) read from these constants
+so the rules are defined once. The config module is *not* a conftest and is
+not collected by pytest; it is imported by `tests/conftest.py` and the
+runtime plugin.
 
-**Trade-off**: A new private string added to the personal persona's
-`prompt.md` is not automatically added to the deny-list. This is accepted:
-the canonical test-privacy signal is the *path* (which is enumerable);
-content-string checking is a defense-in-depth against a small set of known
-past offenders.
+**Why**: Single source of truth. Adding a new persona name (e.g. when P6
+populates `personas/work/`) is a one-line change in one place. The config
+module's own constants are not subject to the guard's substring scan
+because the scan only inspects test files (`test_*.py` and `*_test.py`),
+not arbitrary helper modules.
+
+**Trade-off**: Earlier draft used a `FORBIDDEN_CONTENT_STRINGS` list of
+private prompt phrases. **Removed.** Per Round 1 review (cross-confirmed by
+three reviewers from different angles), the strings we could enumerate
+("Personal Persona Context", "Personal Context Additions") are present in
+the public fixture verbatim, so the deny-list would either flag legitimate
+fixture-based assertions or be useless. The public repo cannot know which
+strings are private inside the submodule; path-based enforcement is the
+only enumerable signal we actually have. This is captured as NG5.
 
 ### D3: Submodule test suite parses YAML directly, not via `PersonaConfig`
 
@@ -97,39 +130,66 @@ agent harness (e.g. the future MS Agent Framework harness, or a Go/Rust
 consumer). The data contract is the YAML shape, not the Python class — so
 tests should validate the YAML shape.
 
-**Trade-off**: Minor duplication of structural knowledge (the submodule tests
-"know" that `database.url_env` should exist, which `PersonaConfig.__init__`
-also knows). We accept this because the alternative — coupling the submodule
-to a specific harness's dataclass — is worse.
+**Trade-off**: Minor duplication of structural knowledge (the submodule
+tests "know" that `database.url_env` should exist, which
+`PersonaConfig.__init__` also knows). We accept this because the
+alternative — coupling the submodule to a specific harness's dataclass — is
+worse.
 
-### D4: Submodule's `pyproject.toml` declares pytest + PyYAML only
+### D4: Submodule pyproject + venv isolation
 
 **Decision**: `personas/personal/pyproject.toml` declares the minimum needed
-for its own test suite: `pytest`, `pyyaml`. No build system (`build-backend`
-left out; this is not an installable package).
+for its own test suite: `pytest`, `pyyaml`. It also declares
+`[tool.uv]` with `package = false` and an empty `workspace.members`, so
+`uv` invoked from inside the submodule does **not** walk up to the parent
+project and reuse its venv.
 
-**Why**: Keeps the submodule minimal. No `src/`, no entry points, no packages
-— just enough to let `uv run pytest` or `pytest` work when invoked inside the
-submodule.
+The submodule's standalone-proof verification (task 3.6) creates a
+**fresh** venv (`uv venv` inside `/tmp/...` or `python -m venv`), installs
+only `pytest` and `pyyaml`, and runs the submodule suite there. It does
+**not** use `PYTHONPATH=/dev/null` (which has no effect on installed
+packages).
 
-**Trade-off**: The submodule cannot be `pip install`ed or imported as a
-Python package. This is correct: it's a *data* artifact, not a library.
+The submodule suite includes a positive runtime check
+(`tests/test_no_assistant_import.py`) that calls
+`importlib.import_module('assistant')` inside `pytest.raises(ImportError)`.
+A pure-grep check is insufficient — `__import__('assistant')` and
+`importlib.import_module('assistant')` both bypass it.
 
-### D5: Parent-repo `roles/` resolved via `../../roles/` from submodule tests
+**Why**: Earlier draft assumed that putting tests under `personas/personal/`
+with their own pyproject would isolate them. Round 1 review (A1) showed
+that `uv run pytest` invoked from inside the submodule will discover the
+parent project root and reuse its venv unless an explicit workspace
+boundary is declared. Without isolation, `import assistant` succeeds
+silently and the self-containment claim is unverifiable.
+
+**Trade-off**: Adds two short config blocks (`[tool.uv]` boundary, fresh-venv
+verification step) to the submodule. Acceptable: the cost is small and the
+alternative — believing self-containment without proving it — is worthless.
+
+### D5: Parent-repo `roles/` resolved via `../../roles/` from submodule tests, with explicit standalone opt-in
 
 **Decision**: When the submodule suite validates that a role override
 references an existing base role, it resolves the base roles directory via
 `Path(__file__).resolve().parents[2] / "roles"` (two levels up from
 `personas/personal/tests/test_xxx.py` → parent repo's `roles/`).
 
-**Why**: Submodule tests are typically invoked from inside a parent checkout.
-When run standalone (without a parent), the base-role check can degrade to a
-warn-and-skip: if `../../roles/` does not exist, the relevant test is
-`pytest.skip`ed with a clear message.
+If `../../roles/` does not exist, the affected test calls
+`pytest.fail("parent roles/ not reachable; set ALLOW_STANDALONE_SUBMODULE_SKIP=1 to bypass")`
+unless the env var `ALLOW_STANDALONE_SUBMODULE_SKIP=1` is set, in which
+case the test is `pytest.skip`ed with a loud message.
 
-**Trade-off**: Standalone execution is less strict. Acceptable: standalone
-mode is for smoke-testing the submodule's YAML shape; the strongest
-invariants (base-role existence) are only meaningful in the parent checkout.
+**Why**: Round 1 review (A6) flagged that a silent skip mode lets broken
+role overrides land — a contributor running the submodule standalone would
+see green, push, and only discover the breakage when someone runs the full
+parent. Requiring explicit opt-in for the weak mode keeps the strong
+invariant on by default; the env var lets a submodule maintainer
+explicitly acknowledge they're skipping the cross-repo check.
+
+**Trade-off**: A submodule maintainer running tests purely inside the
+submodule has to remember the env var. Mitigation: the failure message
+includes the exact env var to set; the docs (G6 in `docs/gotchas.md`)
+record it.
 
 ### D6: Remove CI populate step entirely, not leave it as a safety net
 
@@ -138,29 +198,77 @@ invariants (base-role existence) are only meaningful in the parent checkout.
 **Why**: Leaving it in place creates a **silent divergence trap**: a
 developer who accidentally reintroduces `REPO_ROOT / "personas"` into
 `conftest.py` would have CI pass (because the populate step overlays the
-fixture) but local runs against a real submodule might fail — or succeed with
-stale content. Removing the step means any leak attempt fails loudly in CI.
+fixture) but local runs against a real submodule might fail — or succeed
+with stale content. Removing the step means any leak attempt fails loudly
+in CI.
 
 **Trade-off**: If the conftest guard is ever disabled or broken, CI has no
 second line of defense. Accepted: the conftest guard is a pure-Python,
 in-repo check with low failure surface; duplicating its intent in YAML adds
 coordination overhead for negligible robustness gain.
 
-### D7: Submodule changes ship as two commits (parent + submodule)
+### D7: Submodule changes ship as two commits with an atomic push wrapper
 
-**Decision**: The implementation commits submodule content inside the
-submodule's own history, pushes to its remote, then updates the parent repo's
-submodule pointer in a separate commit.
+**Decision**: A reusable script
+`scripts/push-with-submodule.sh` performs the dual-commit sequence
+atomically: (1) verify parent is rebased onto `origin/main`, (2) commit
+submodule-side changes inside `personas/personal/`, (3) push submodule, (4)
+update parent gitlink and commit, (5) push parent. On failure of step 5
+after step 3 has succeeded, the script logs the dangling submodule SHA and
+the operator-recovery command (force-delete the dangling submodule branch
+or open a ticket) without attempting automatic rollback.
 
-**Why**: That's how submodules work — a parent commit only records a SHA
-reference. We can't "carry" submodule file changes in a parent-repo diff.
+**Why**: Round 1 review (A8) flagged the failure mode where submodule push
+succeeds but parent push fails (network race, branch-protection drift), and
+the inverse. A documented atomic wrapper centralizes the recovery story.
+Also: parent-repo PR diff shows only the submodule SHA bump; reviewers
+inspecting submodule content must check it out at the new SHA or be
+pointed at the private-repo PR.
 
-**Constraint on implementation**: The parent-repo PR's diff will show only
-the submodule SHA bump for `personas/personal/`. Reviewers inspecting the
-content must either check out the submodule at the new SHA or be pointed at
-the private-repo PR. The `/validate-feature` + `/parallel-review-implementation`
-steps downstream must handle this correctly — they'll need to clone the
-submodule at the new SHA to review its tests.
+**Trade-off**: One additional script under `scripts/`. The script is
+required for tasks 5.3a/5.3b; ad-hoc `git push` is no longer the documented
+path.
+
+### D8: `tests/fixtures/` allow-list is restricted to data files
+
+**Decision**: The runtime FS guard's allow-list is `tests/fixtures/**/*` for
+data files (`.yaml`, `.yml`, `.md`, `.json`, `.txt`) only. Python files
+under `tests/fixtures/` are **not** allow-listed; if a `.py` file there
+attempts to read `personas/personal/`, the runtime guard fires.
+`tests/fixtures/__init__.py` (empty marker) is the sole exception.
+
+**Why**: Round 1 review (A5) showed that bulk-allowing `tests/fixtures/`
+opens a smuggling channel: a `tests/fixtures/loader.py` that imports +
+re-exports real submodule content launders private data through a path
+the substring guard treats as trusted. Narrowing the allow-list to data
+files closes the channel.
+
+**Trade-off**: A future contributor wanting a Python helper under
+`tests/fixtures/` must put it elsewhere (e.g. `tests/_helpers/`). Minor;
+documented in `docs/gotchas.md`.
+
+### D9: Guard scope = test files + conftest, with self-exclusion
+
+**Decision**: The Layer 1 (substring scan) inspects:
+- All files matching `tests/**/test_*.py` and `tests/**/*_test.py`.
+- All files matching `tests/**/conftest.py`.
+
+It does **not** inspect:
+- `tests/_privacy_guard_config.py` (definitions of the deny-list itself).
+- `tests/_privacy_guard_plugin.py` (the runtime guard implementation).
+- Files under `tests/fixtures/`.
+
+**Why**: Round 1 review (A3, A4) raised that conftest fixtures are imported,
+not collected, so a fixture returning a forbidden path bypasses a
+collection-only scan. Including conftest in the scan closes that gap.
+The two `_privacy_guard_*.py` files are explicitly excluded because they
+are the deny-list's own implementation; if they were scanned, the guard
+would self-trip on its own constants.
+
+**Trade-off**: The exclusion list is now four files (two scanned, two
+not). Mitigation: the exclusion is hard-coded in
+`_privacy_guard_config.py` as a tuple, not configurable, so the surface
+for "exclusion drift" is small.
 
 ## Risks
 
@@ -169,8 +277,9 @@ submodule at the new SHA to review its tests.
 If someone updates the real `personas/personal/persona.yaml` but forgets to
 update `tests/fixtures/personas/personal/persona.yaml`, public tests will
 continue passing against the stale fixture while the real submodule changes
-shape. The submodule's own test suite catches shape-drift inside the private
-repo, but cross-checking *between* fixture and real submodule is not enforced.
+shape. The submodule's own test suite catches shape-drift inside the
+private repo, but cross-checking *between* fixture and real submodule is
+not enforced.
 
 **Mitigation**: Add a `docs/gotchas.md` entry reminding developers that
 fixture and submodule YAML are intentionally decoupled, and that structural
@@ -178,27 +287,42 @@ changes to either should be mirrored manually. Out of scope: an automated
 parity test — that would reintroduce the private-content coupling we just
 removed.
 
-### R2: Collection guard has false positives
+### R2: Layer 2 monkey-patching has scope/timing risks
 
-A test that quotes the string `personas/personal/` inside a comment or
-docstring (e.g., describing *why* a fixture path was changed) would trip the
-guard.
+The runtime FS guard patches `pathlib.Path.open`, `Path.read_text`,
+`Path.read_bytes`, and `builtins.open`. If a parent-repo dependency reads
+files using a non-stdlib I/O path (e.g. a C extension that bypasses
+`builtins.open`), the runtime guard cannot see those reads.
 
-**Mitigation**: The guard allow-list includes `tests/fixtures/`, so fixture
-files can contain any content. For commentary in test files, recommend
-contributors describe the rule in reference form (e.g., "the guard in
-conftest.py rejects...") rather than quoting a path literal. If this proves
-too restrictive in practice, upgrade the guard to AST-based inspection (skip
-string literals inside `ast.Constant` nodes that are clearly comments or
-module-level doctrings) as a follow-up — not in scope for this change.
+**Mitigation**: For the consumer set we have (`yaml.safe_load`, `Path.open`,
+`open()`, `read_text`/`read_bytes`), the patch surface is sufficient.
+Document the limitation: tests that use mmap, ctypes-based I/O, or shell
+subprocesses are outside Layer 2's coverage; for those, Layer 1's
+substring scan is the only line of defense.
 
 ### R3: Submodule push requires private-repo write access
 
-Implementation requires commit-and-push inside `personas/personal/`, which is
-a private GitHub repo. Any agent executing this work must have credentials
-for that remote.
+Implementation requires commit-and-push inside `personas/personal/`, which
+is a private GitHub repo. Any agent executing this work must have
+credentials for that remote.
 
-**Mitigation**: IMPLEMENT phase must be a single-agent (or co-located agents)
-job for the `wp-submodule-tests` package. Cannot run in a vendor container
-without the private-repo SSH key. Documented in `work-packages.yaml` as a
-constraint.
+**Mitigation**: Tasks 5.3a and 5.3b are split into separate work packages
+(`wp-submodule-tests` for 5.3a; `wp-integration` for 5.3b). Both packages
+declare `constraints.requires_private_repo_write: true`. If credentials
+are unavailable, the dispatcher quarantines the package for operator
+pickup rather than failing silently. Task 5.3-alt documents the manual
+recovery path.
+
+### R4: Future CI workflows could re-introduce dependency on populated mount
+
+Removing the populate step (D6) silently breaks any future GitHub Actions
+workflow that does `assistant -p personal --check` (or similar) and
+expects `personas/personal/persona.yaml` to exist at the mount point.
+
+**Mitigation**: Add a public test
+`tests/test_ci_workflow_hygiene.py` (task 4.4 below) that scans every
+`.github/workflows/*.yml` for references to `personas/personal/` or
+`personas/work/` and fails if any are not paired with an explicit
+copy-from-fixture step or a routing through the fixture path. Catches the
+regression at the same single-point-of-enforcement the rest of this change
+relies on.

--- a/openspec/changes/test-privacy-boundary/design.md
+++ b/openspec/changes/test-privacy-boundary/design.md
@@ -1,0 +1,204 @@
+# Design: test-privacy-boundary
+
+## Context
+
+The public repo contains persona-consuming test code; the private repo (the
+`personas/personal/` submodule) contains persona *data*. The current
+`tests/conftest.py` resolves `personas_dir` to `REPO_ROOT / "personas"`, which
+points at the submodule mount. Public tests can therefore read private data
+and encode private strings as assertions. This change repartitions testing
+along the existing privacy seam rather than introducing a new abstraction.
+
+## Goals
+
+- **G1**: Public tests must run to green without the private submodule being
+  populated.
+- **G2**: Any attempt to introduce a reference to `personas/personal/` or
+  `personas/work/` (or private-content strings) from within public `tests/`
+  must fail at collection time, with a clear remediation message.
+- **G3**: The `personas/personal/` submodule must own its own test suite
+  that runs *without importing anything from `src/assistant/`*, so the
+  persona data is reusable by a non-Python harness.
+- **G4**: The CI workaround (commit `76a313e`) must be removed, eliminating
+  the "keep fixture in sync with submodule" maintenance burden.
+
+## Non-goals
+
+- **NG1**: This change does not alter `PersonaConfig`, `PersonaRegistry`,
+  `RoleConfig`, or `RoleRegistry` semantics. It only changes what directory
+  those classes read from in public tests.
+- **NG2**: This change does not introduce a generic "redaction" or
+  secrets-management layer for persona content. Personas are private, not
+  secret.
+- **NG3**: This change does not populate `personas/work/`. P6
+  (`work-persona-config`) remains the home for that work.
+
+## Key decisions
+
+### D1: Collection-time guard, not runtime guard
+
+**Decision**: Enforcement runs as a `pytest_collection_modifyitems` hook that
+reads each collected test file's source text and refuses to continue if it
+contains a forbidden substring.
+
+**Why**: The guard must fail **before** any test body executes, so a developer
+who writes a leak locally gets immediate, unambiguous feedback. A runtime
+guard (e.g., patching `Path.open` to deny reads under `personas/`) would only
+fire during execution, producing confusing late failures and potentially
+missing never-run code paths.
+
+**Trade-off**: Collection-time source inspection is coarse — it matches on
+substrings, not on AST-level semantics. A test that builds the forbidden path
+via string concatenation (`"personas/" + "personal"`) would slip past. We
+accept this because (a) the threat model is accidental leakage, not
+adversarial circumvention, and (b) if such a test were written, the *content
+string* deny-list (`"Personal Persona Context"` etc.) would catch its
+assertions anyway.
+
+### D2: Deny-list is configured, not hardcoded
+
+**Decision**: The guard reads its path-prefix deny-list and private-content
+string deny-list from a constant near the top of `tests/conftest.py`:
+
+```python
+FORBIDDEN_PATH_SUBSTRINGS = (
+    "personas/personal/",
+    "personas/work/",
+)
+FORBIDDEN_CONTENT_STRINGS = (
+    "Personal Persona Context",
+    "Personal Context Additions",
+)
+ALLOWED_PATH_SUBSTRINGS = (
+    "personas/_template/",
+    "tests/fixtures/",
+)
+```
+
+**Why**: Keeps the rules one scroll away from any developer writing tests,
+and makes it trivial to extend when new persona names or private prompt
+phrases are introduced. Avoids pulling in a YAML/TOML config file for a
+three-tuple of constants.
+
+**Trade-off**: A new private string added to the personal persona's
+`prompt.md` is not automatically added to the deny-list. This is accepted:
+the canonical test-privacy signal is the *path* (which is enumerable);
+content-string checking is a defense-in-depth against a small set of known
+past offenders.
+
+### D3: Submodule test suite parses YAML directly, not via `PersonaConfig`
+
+**Decision**: `personas/personal/tests/` uses `yaml.safe_load` + dict-shaped
+assertions. It does not import `assistant.core.persona.PersonaConfig`.
+
+**Why**: The self-containment goal (G3). If these tests imported the parent
+harness, they'd break the moment the submodule is consumed by a non-Python
+agent harness (e.g. the future MS Agent Framework harness, or a Go/Rust
+consumer). The data contract is the YAML shape, not the Python class — so
+tests should validate the YAML shape.
+
+**Trade-off**: Minor duplication of structural knowledge (the submodule tests
+"know" that `database.url_env` should exist, which `PersonaConfig.__init__`
+also knows). We accept this because the alternative — coupling the submodule
+to a specific harness's dataclass — is worse.
+
+### D4: Submodule's `pyproject.toml` declares pytest + PyYAML only
+
+**Decision**: `personas/personal/pyproject.toml` declares the minimum needed
+for its own test suite: `pytest`, `pyyaml`. No build system (`build-backend`
+left out; this is not an installable package).
+
+**Why**: Keeps the submodule minimal. No `src/`, no entry points, no packages
+— just enough to let `uv run pytest` or `pytest` work when invoked inside the
+submodule.
+
+**Trade-off**: The submodule cannot be `pip install`ed or imported as a
+Python package. This is correct: it's a *data* artifact, not a library.
+
+### D5: Parent-repo `roles/` resolved via `../../roles/` from submodule tests
+
+**Decision**: When the submodule suite validates that a role override
+references an existing base role, it resolves the base roles directory via
+`Path(__file__).resolve().parents[2] / "roles"` (two levels up from
+`personas/personal/tests/test_xxx.py` → parent repo's `roles/`).
+
+**Why**: Submodule tests are typically invoked from inside a parent checkout.
+When run standalone (without a parent), the base-role check can degrade to a
+warn-and-skip: if `../../roles/` does not exist, the relevant test is
+`pytest.skip`ed with a clear message.
+
+**Trade-off**: Standalone execution is less strict. Acceptable: standalone
+mode is for smoke-testing the submodule's YAML shape; the strongest
+invariants (base-role existence) are only meaningful in the parent checkout.
+
+### D6: Remove CI populate step entirely, not leave it as a safety net
+
+**Decision**: `.github/workflows/ci.yml` loses its populate-personas step.
+
+**Why**: Leaving it in place creates a **silent divergence trap**: a
+developer who accidentally reintroduces `REPO_ROOT / "personas"` into
+`conftest.py` would have CI pass (because the populate step overlays the
+fixture) but local runs against a real submodule might fail — or succeed with
+stale content. Removing the step means any leak attempt fails loudly in CI.
+
+**Trade-off**: If the conftest guard is ever disabled or broken, CI has no
+second line of defense. Accepted: the conftest guard is a pure-Python,
+in-repo check with low failure surface; duplicating its intent in YAML adds
+coordination overhead for negligible robustness gain.
+
+### D7: Submodule changes ship as two commits (parent + submodule)
+
+**Decision**: The implementation commits submodule content inside the
+submodule's own history, pushes to its remote, then updates the parent repo's
+submodule pointer in a separate commit.
+
+**Why**: That's how submodules work — a parent commit only records a SHA
+reference. We can't "carry" submodule file changes in a parent-repo diff.
+
+**Constraint on implementation**: The parent-repo PR's diff will show only
+the submodule SHA bump for `personas/personal/`. Reviewers inspecting the
+content must either check out the submodule at the new SHA or be pointed at
+the private-repo PR. The `/validate-feature` + `/parallel-review-implementation`
+steps downstream must handle this correctly — they'll need to clone the
+submodule at the new SHA to review its tests.
+
+## Risks
+
+### R1: Submodule tests drift from fixture content
+
+If someone updates the real `personas/personal/persona.yaml` but forgets to
+update `tests/fixtures/personas/personal/persona.yaml`, public tests will
+continue passing against the stale fixture while the real submodule changes
+shape. The submodule's own test suite catches shape-drift inside the private
+repo, but cross-checking *between* fixture and real submodule is not enforced.
+
+**Mitigation**: Add a `docs/gotchas.md` entry reminding developers that
+fixture and submodule YAML are intentionally decoupled, and that structural
+changes to either should be mirrored manually. Out of scope: an automated
+parity test — that would reintroduce the private-content coupling we just
+removed.
+
+### R2: Collection guard has false positives
+
+A test that quotes the string `personas/personal/` inside a comment or
+docstring (e.g., describing *why* a fixture path was changed) would trip the
+guard.
+
+**Mitigation**: The guard allow-list includes `tests/fixtures/`, so fixture
+files can contain any content. For commentary in test files, recommend
+contributors describe the rule in reference form (e.g., "the guard in
+conftest.py rejects...") rather than quoting a path literal. If this proves
+too restrictive in practice, upgrade the guard to AST-based inspection (skip
+string literals inside `ast.Constant` nodes that are clearly comments or
+module-level doctrings) as a follow-up — not in scope for this change.
+
+### R3: Submodule push requires private-repo write access
+
+Implementation requires commit-and-push inside `personas/personal/`, which is
+a private GitHub repo. Any agent executing this work must have credentials
+for that remote.
+
+**Mitigation**: IMPLEMENT phase must be a single-agent (or co-located agents)
+job for the `wp-submodule-tests` package. Cannot run in a vendor container
+without the private-repo SSH key. Documented in `work-packages.yaml` as a
+constraint.

--- a/openspec/changes/test-privacy-boundary/design.md
+++ b/openspec/changes/test-privacy-boundary/design.md
@@ -66,13 +66,30 @@ collection-time advisory + runtime filesystem guard as authoritative).
   before any test body runs.
 - **Layer 2 (authoritative, runtime)**: A pytest plugin (registered via
   `tests/_privacy_guard_plugin.py` and loaded via `pytest_plugins` in
-  `tests/conftest.py`) patches `pathlib.Path.open`, `pathlib.Path.read_text`,
-  `pathlib.Path.read_bytes`, and `builtins.open` for the duration of test
-  collection and execution. Any attempt to open a path that resolves under
-  `personas/<name>/` (where `<name>` is in `FORBIDDEN_PATH_NAMES`) raises
+  `tests/conftest.py`) patches the following I/O entry points for the
+  duration of test collection and execution:
+  - `pathlib.Path.open`, `pathlib.Path.read_text`, `pathlib.Path.read_bytes`
+  - `builtins.open`
+  - `os.open` (the canonical syscall choke point; `io.FileIO`,
+    `codecs.open`, `io.open`, and `open()` all route through it)
+  - `subprocess.Popen.__init__` (scans `args`/`argv` for forbidden path
+    substrings, closing the "Copilot writes `subprocess.run(['cat', ...])`"
+    bypass class — Round 2 finding B-N1)
+
+  Any attempt to open/read a path that resolves under `personas/<name>/`
+  (where `<name>` is in `FORBIDDEN_PATH_NAMES`), or to spawn a subprocess
+  whose argv contains such a path literal or a string constructible as
+  such (see Round 2 finding B-N1 for the bypass class this closes), raises
   `_PrivacyBoundaryViolation`, which inherits from `pytest.UsageError`.
   Allow-listed read paths under `tests/fixtures/` and `personas/_template/`
   are permitted.
+
+  **Plugin self-probe (B-N8)**: At `pytest_configure` time, after installing
+  the patches, the plugin opens a canary path under `personas/personal/`
+  and asserts `_PrivacyBoundaryViolation` is raised. If the patches failed
+  to install (e.g., future CPython refuses Python-level rebinding of a
+  C-slot method), the self-probe fails loudly via `pytest.UsageError`
+  before any real test runs. Prevents the silent-disable failure mode.
 
 **Why**: Layer 1 alone cannot stop the standard
 `Path("personas") / persona_name / "persona.yaml"` idiom — Copilot and
@@ -140,32 +157,56 @@ worse.
 
 **Decision**: `personas/personal/pyproject.toml` declares the minimum needed
 for its own test suite: `pytest`, `pyyaml`. It also declares
-`[tool.uv]` with `package = false` and an empty `workspace.members`, so
-`uv` invoked from inside the submodule does **not** walk up to the parent
-project and reuse its venv.
+`[tool.uv]` with `package = false` and an empty `workspace.members`, and
+pins `uv >= 0.5.0` in the fresh-venv verification script because the
+`[tool.uv].package` field semantics stabilized at that version (Round 2
+finding B-N6).
 
 The submodule's standalone-proof verification (task 3.6) creates a
-**fresh** venv (`uv venv` inside `/tmp/...` or `python -m venv`), installs
-only `pytest` and `pyyaml`, and runs the submodule suite there. It does
-**not** use `PYTHONPATH=/dev/null` (which has no effect on installed
-packages).
+**fresh** venv (`python -m venv` with the script's own Python
+interpreter), installs only `pytest` and `pyyaml` with pinned minimums,
+and runs the submodule suite there. The script `cd`s into
+`personas/personal/` before invoking pytest so the submodule's pyproject
+is pytest's rootdir, not the parent's — otherwise the parent's
+`pytest_plugins` (the privacy guard) would be loaded and could fire on
+legitimate submodule reads (Round 2 finding B-N7). It does **not** use
+`PYTHONPATH=/dev/null` (which has no effect on installed packages).
 
 The submodule suite includes a positive runtime check
 (`tests/test_no_assistant_import.py`) that calls
-`importlib.import_module('assistant')` inside `pytest.raises(ImportError)`.
-A pure-grep check is insufficient — `__import__('assistant')` and
-`importlib.import_module('assistant')` both bypass it.
+`importlib.import_module('assistant.core.persona')` — NOT just
+`importlib.import_module('assistant')` — inside `pytest.raises(ImportError)`.
+The qualified path is distinctive to this project and will not collide
+with the unrelated PyPI package named `assistant` that a contributor
+could have pip-installed for other work (Round 2 finding B-N5). A
+pure-grep check is insufficient — `__import__` and
+`importlib.import_module` both bypass it.
+
+**Forward-compatibility guard**: A parent-repo test
+(`tests/test_workspace_hygiene.py`, added alongside the workflow-hygiene
+test in Phase 4) asserts that the parent `pyproject.toml` does NOT
+declare `[tool.uv.workspace]` with `personas/*` as a member. If someone
+later adds `members = ['personas/*']` for dev ergonomics, the submodule's
+own `workspace.members = []` cannot override inclusion (membership is
+declared by the workspace root, not the member). The guard catches this
+regression class explicitly (Round 2 finding B-N6).
 
 **Why**: Earlier draft assumed that putting tests under `personas/personal/`
 with their own pyproject would isolate them. Round 1 review (A1) showed
-that `uv run pytest` invoked from inside the submodule will discover the
-parent project root and reuse its venv unless an explicit workspace
-boundary is declared. Without isolation, `import assistant` succeeds
-silently and the self-containment claim is unverifiable.
+`uv run pytest` from inside the submodule would reuse the parent venv
+without an explicit workspace boundary. Round 2 review (B-N5, B-N6, B-N7)
+further found that (a) the `assistant` PyPI package name could collide
+with an unrelated install and make the positive-import assertion
+misleading, (b) the workspace boundary is one-directional — parent-
+declared membership overrides member-declared `workspace.members = []`,
+so a future parent change could silently reintroduce the leak, and (c)
+pytest's rootdir discovery from parent cwd could load parent plugins
+against submodule tests.
 
-**Trade-off**: Adds two short config blocks (`[tool.uv]` boundary, fresh-venv
-verification step) to the submodule. Acceptable: the cost is small and the
-alternative — believing self-containment without proving it — is worthless.
+**Trade-off**: Adds several short config blocks (version pin, workspace
+forward-compat guard, cd-before-pytest in the verification script) to
+the submodule + parent. Acceptable: each one closes a concrete gap
+Round 1/2 surfaced, and the cost is small.
 
 ### D5: Parent-repo `roles/` resolved via `../../roles/` from submodule tests, with explicit standalone opt-in
 
@@ -258,17 +299,42 @@ It does **not** inspect:
 - `tests/_privacy_guard_plugin.py` (the runtime guard implementation).
 - Files under `tests/fixtures/`.
 
+**Additional rule (Round 2 finding B-N4)**: The test files that legitimately
+need to reference forbidden path substrings — specifically
+`tests/test_ci_workflow_hygiene.py` (which greps workflow YAML for
+leakage) and `tests/test_workspace_hygiene.py` (which greps the parent
+pyproject for `personas/*` workspace membership) — SHALL **not** use
+the substring as a literal in their source. Instead, they SHALL import
+`FORBIDDEN_PATH_NAMES` from `tests/_privacy_guard_config.py` and
+construct the needle dynamically:
+
+```python
+from tests._privacy_guard_config import FORBIDDEN_PATH_NAMES
+needles = tuple(f"personas/{name}/" for name in FORBIDDEN_PATH_NAMES)
+```
+
+This keeps the test file free of forbidden literals (so Layer 1 doesn't
+self-trip) and auto-extends when new persona names are added to the
+deny-list. Belt-and-suspenders: the hygiene-test filenames are **also**
+added to the Layer 1 exclusion list, so a literal substring slipping
+back in during future maintenance still doesn't cause a hard session
+failure — it fails the hygiene test's own assertion instead, with a
+better diagnostic.
+
 **Why**: Round 1 review (A3, A4) raised that conftest fixtures are imported,
 not collected, so a fixture returning a forbidden path bypasses a
 collection-only scan. Including conftest in the scan closes that gap.
-The two `_privacy_guard_*.py` files are explicitly excluded because they
-are the deny-list's own implementation; if they were scanned, the guard
-would self-trip on its own constants.
+Round 2 review (B-N4) raised that the hygiene-test files need the
+forbidden substring as *data* for their own scanning logic; a naive
+implementation would self-trip Layer 1. The dynamic-needle pattern
+resolves it cleanly.
 
-**Trade-off**: The exclusion list is now four files (two scanned, two
-not). Mitigation: the exclusion is hard-coded in
-`_privacy_guard_config.py` as a tuple, not configurable, so the surface
-for "exclusion drift" is small.
+**Trade-off**: The exclusion list is now six files (test_*.py and
+conftest.py scanned; `_privacy_guard_config.py`,
+`_privacy_guard_plugin.py`, `test_ci_workflow_hygiene.py`,
+`test_workspace_hygiene.py` excluded). Mitigation: the exclusion is
+hard-coded in `_privacy_guard_config.py` as a tuple, not configurable,
+so the surface for "exclusion drift" is small.
 
 ## Risks
 
@@ -290,15 +356,39 @@ removed.
 ### R2: Layer 2 monkey-patching has scope/timing risks
 
 The runtime FS guard patches `pathlib.Path.open`, `Path.read_text`,
-`Path.read_bytes`, and `builtins.open`. If a parent-repo dependency reads
-files using a non-stdlib I/O path (e.g. a C extension that bypasses
-`builtins.open`), the runtime guard cannot see those reads.
+`Path.read_bytes`, `builtins.open`, `os.open`, and
+`subprocess.Popen.__init__`. After Round 2 finding B-N2, `os.open` is
+the canonical syscall-level choke point covering `io.FileIO`,
+`codecs.open`, `io.open`, and higher-level wrappers. After Round 2
+finding B-N1, `subprocess.Popen.__init__` catches the
+`subprocess.run(['cat', path])` bypass class by scanning argv elements
+for forbidden substrings.
 
-**Mitigation**: For the consumer set we have (`yaml.safe_load`, `Path.open`,
-`open()`, `read_text`/`read_bytes`), the patch surface is sufficient.
-Document the limitation: tests that use mmap, ctypes-based I/O, or shell
-subprocesses are outside Layer 2's coverage; for those, Layer 1's
-substring scan is the only line of defense.
+**Remaining out-of-coverage surface**:
+- **mmap.mmap** on an already-opened file descriptor: if a test opens a
+  file (which Layer 2 would catch) and mmaps it, the mmap read is
+  invisible. Already-opened-then-mmap requires first getting past the
+  open patch, so this is low-risk.
+- **ctypes-based I/O** bypassing the stdlib entirely. Rare in tests.
+- **os.system** and **os.popen** (both use the shell). Layer 2 does
+  patch `subprocess.Popen` and `os.system` dispatches through it on
+  POSIX, but on Windows `os.system` calls `cmd.exe` directly. Document
+  this as a known gap; `os.system` is rare in modern test code.
+- **Subprocess argv with a forbidden path split across multiple argv
+  elements** (e.g. `cat personas/personal/persona.yaml` might be
+  `['cat', 'personas/personal/persona.yaml']` — caught — but a
+  sufficiently-motivated reconstruction like
+  `['sh', '-c', f'cat personas/{name}/x']` with `name = "personal"`
+  obtained via an environment variable at subprocess time is
+  uncatchable at argv-inspection time). Accepted: this crosses from
+  "accidental Copilot idiom" into "deliberate evasion", outside the
+  documented threat model.
+
+**Mitigation**: Document these gaps explicitly in
+`docs/gotchas.md` G6 so future contributors know which I/O patterns are
+structurally unsupervised. Layer 1's substring scan remains the only
+line of defense for those cases, and catches any literal
+`personas/personal/` appearance regardless of the I/O style.
 
 ### R3: Submodule push requires private-repo write access
 

--- a/openspec/changes/test-privacy-boundary/proposal.md
+++ b/openspec/changes/test-privacy-boundary/proposal.md
@@ -208,3 +208,38 @@ Approaches 2 and 3 are not selected:
   `requires_private_repo_write`; `wp-ci-cleanup` now depends on
   `wp-public-tests`; `wp-integration` deny-lists submodule content so it
   cannot accidentally write there).
+
+### Changes from Round 2 review
+
+- **Extended Layer 2 patch surface** (finding B-N1, B-N2): the runtime
+  guard now also patches `os.open` (covers `io.FileIO`, `codecs.open`,
+  `io.open`) and `subprocess.Popen.__init__` (scans argv for forbidden
+  substrings, closing the `subprocess.run(['cat', path])` bypass class).
+- **Added plugin self-probe** (B-N8): at `pytest_configure`, the plugin
+  verifies its patches are active by attempting a canary forbidden read;
+  fails the session if the patches silently failed to install.
+- **Qualified the positive-import assertion** (B-N5): submodule tests
+  now assert `importlib.import_module("assistant.core.persona")` raises
+  ImportError — the qualified path avoids collision with the unrelated
+  PyPI package also named `assistant`.
+- **Added parent-workspace forward-compat guard** (B-N6): a new
+  `tests/test_workspace_hygiene.py` asserts the parent `pyproject.toml`
+  does NOT declare `personas/*` as a uv workspace member, preventing a
+  future dev-ergonomics change from silently defeating self-containment.
+- **Fresh-venv script now cd-before-pytest** (B-N7): eliminates the
+  rootdir-discovery ambiguity that would load parent `pytest_plugins`
+  against submodule tests.
+- **Hygiene tests use dynamic needle construction** (B-N4): the files
+  that need to reference `personas/<name>/` substrings as *data* import
+  `FORBIDDEN_PATH_NAMES` from the deny-list config instead of embedding
+  literals, so Layer 1 doesn't self-trip. Belt-and-suspenders: added to
+  the Layer 1 exclusion list as well.
+- **Added push-script authoring task** (B-N3): task 5.0 creates
+  `scripts/push-with-submodule.sh` with documented exit-code contract
+  (exit 47 for push failure after partial success) that 5.3-alt parses.
+- **Clarified task 5.3-alt trigger semantics** (A-N2): dispatch-time
+  constraint-driven quarantine + runtime exit-code-47 fallback, both
+  documented as the explicit dual contract.
+- **Removed 5.3b↔5.4 "subsumed" ambiguity** (A-N1): 5.3b pushes the
+  parent branch; 5.4 opens the PR via `gh pr create`. They are now
+  unambiguously distinct steps.

--- a/openspec/changes/test-privacy-boundary/proposal.md
+++ b/openspec/changes/test-privacy-boundary/proposal.md
@@ -1,0 +1,151 @@
+# Proposal: test-privacy-boundary
+
+## Why
+
+The public test suite currently reads from, and asserts on, content that lives
+inside the private `personas/personal/` git submodule. This creates three
+concrete problems:
+
+1. **Private-content leakage into the public repo.** Assertions like
+   `tests/test_composition.py:119` (`"Personal Persona Context" in out`) and
+   `tests/test_role_registry.py:67` (`"Personal Context Additions" in role.prompt`)
+   lift exact strings from the private submodule's prompt files. Anyone reading
+   the public test suite learns non-trivial facts about the private persona's
+   prompt structure and role overrides.
+
+2. **Silent CI divergence.** Because the public CI cannot clone the private
+   submodule, commit `76a313e` added a workaround (`.github/workflows/ci.yml:41-44`)
+   that overlays `tests/fixtures/personas/personal/` on top of the empty mount
+   point before running pytest. Locally, tests run against the *real* submodule;
+   in CI, against the fixture. Developers can add assertions that only work
+   locally and have CI pass against stale fixture content — or vice versa.
+
+3. **Submodule cannot be reused harness-agnostic.** The `personas/personal/`
+   repo is a *data* artifact. A future MS Agent Framework harness (roadmap P5),
+   or a Go/Rust consumer, should be able to check it out and validate its
+   shape without importing anything from `src/assistant/*`. Today, the only
+   tests that exercise its real content live in the public repo and depend on
+   the Python harness's `PersonaRegistry`.
+
+## What Changes
+
+This change enforces a **privacy boundary** between public and private test
+scopes:
+
+- **Public tests** (in `tests/`) run exclusively against fixtures in
+  `tests/fixtures/personas/`. They never read from `personas/<name>/` at
+  runtime and never assert on strings sourced from the real submodule content.
+- **Persona-specific integration tests** move into each persona's private
+  submodule (e.g. `personas/personal/tests/`), self-contained with their own
+  pyproject and a minimal YAML loader — no dependency on `src/assistant/*`.
+- **A pytest collection-time guard** in `tests/conftest.py` fails loudly if any
+  collected public test file references `personas/(personal|work)/` paths or
+  known private-content strings, with an allow-list for
+  `tests/fixtures/` and `personas/_template/`.
+- **The CI `populate personas/personal from test fixture` step is removed** —
+  the conftest redirect makes the workaround unnecessary.
+- **Documentation** (`CLAUDE.md` Conventions + `docs/gotchas.md`) records the
+  rule so future contributors don't reintroduce the leak.
+
+The boundary guard covers **both `personal` and `work`** from day one (future-
+proofing for P6 — `work-persona-config`), even though `personas/work/` is not
+yet populated.
+
+## Approaches Considered
+
+### Approach 1: Minimal repoint + conftest guard + submodule-side pytest *(Recommended)*
+
+**Description**: `tests/conftest.py` resolves `personas_dir` to
+`REPO_ROOT / "tests" / "fixtures" / "personas"`. Private-content assertions in
+public tests are rewritten against fixture values. Persona-specific integration
+tests (the ones that genuinely validate the real submodule's YAML shape) move
+to `personas/personal/tests/` with their own `pyproject.toml` (pytest + PyYAML)
+and no import from `src/assistant/*`. A `pytest_collection_modifyitems` hook in
+`tests/conftest.py` inspects each collected test file's source and fails if it
+references `personas/(personal|work)/` paths or private-content strings outside
+the allow-list.
+
+**Pros**:
+- Clean separation: public tests never need the submodule initialized
+- Submodule stays harness-agnostic — can be consumed by non-Python harnesses
+- Enforcement runs locally *and* in CI (single mechanism, single place)
+- Removes the CI populate step and its "keep in sync" maintenance burden
+- Matches the team's existing pytest ergonomics on both sides
+
+**Cons**:
+- Submodule grows a small `pyproject.toml` dev-dep section (pytest, PyYAML)
+- Test writers must remember which conftest to target when touching either side
+
+**Effort**: S
+
+### Approach 2: Dual-mode conftest with `@pytest.mark.integration` marker
+
+**Description**: Public `tests/conftest.py` detects whether
+`personas/personal/persona.yaml` exists. If it does, tests marked
+`@pytest.mark.integration` are collected; otherwise they are skipped. Private-
+coupled tests stay in `tests/` but are moved under `tests/integration/` with
+the marker applied. A custom collector refuses imports from
+`personas/<name>/` in un-marked tests. The CI populate step stays (so
+integration tests run in CI against the fixture).
+
+**Pros**:
+- No new repo (submodule stays test-free)
+- Single test tree is easier to navigate
+
+**Cons**:
+- **Leakage not actually fixed**: integration tests still live in the public
+  repo and still assert on private strings. Moving them to a subdirectory is
+  cosmetic; `git log` / `git blame` still show private content being asserted.
+- CI populate step + fixture sync burden persists
+- Submodule is not independently testable by a non-Python harness
+- Marker-gated tests are easy to forget about and decay
+
+**Effort**: S
+
+### Approach 3: Externalize private content into env vars / redacted fixtures
+
+**Description**: Treat every string in the fixture as a placeholder. Real
+prompts and role overrides are loaded at runtime from env vars or a secrets
+directory. Tests assert on structural invariants only (key presence, type,
+schema shape) — never on content.
+
+**Pros**:
+- Zero private content anywhere in either repo
+- Tests are reusable as contract tests for *any* persona
+
+**Cons**:
+- Over-engineered for a config-heavy data artifact
+- Breaks the current persona model (persona YAML literally embeds prompt
+  strings; they're not secrets, they're just *private* in the "not public repo"
+  sense, not "do not log" sense)
+- Large refactor across `PersonaRegistry`, `RoleRegistry`, and every consumer
+- Doesn't address the CI populate-step issue
+
+**Effort**: L
+
+## Selected Approach
+
+**Approach 1** — repoint + guard + submodule-side pytest.
+
+Confirmed during discovery (Gate 1, 2026-04-13):
+
+- **Enforcement mechanism**: pytest conftest collection hook (runs locally
+  *and* in CI; single enforcement point).
+- **Submodule toolchain**: pytest with a minimal `pyproject.toml` in
+  `personas/personal/` declaring pytest + PyYAML as dev deps.
+- **Scope**: covers both `personas/personal/` *and* `personas/work/` from day
+  one, future-proofing the guard for P6 (`work-persona-config`) even though
+  `personas/work/` is not yet populated.
+- **CI cleanup**: the `populate personas/personal from test fixture` step
+  introduced in `76a313e` is **removed** — the conftest repoint makes it
+  redundant.
+
+Approaches 2 and 3 are not selected:
+
+- **Approach 2 (marker-based dual-mode)** — does not actually fix leakage;
+  private strings remain in the public repo's `git log`/`git blame` under a
+  different directory. Cosmetic, not structural.
+- **Approach 3 (env-var placeholders)** — over-engineered. Personas are
+  private, not secret; refactoring every consumer of `PersonaRegistry` and
+  `RoleRegistry` to load prompts from env vars is disproportionate to the
+  problem.

--- a/openspec/changes/test-privacy-boundary/proposal.md
+++ b/openspec/changes/test-privacy-boundary/proposal.md
@@ -53,27 +53,38 @@ yet populated.
 
 ## Approaches Considered
 
-### Approach 1: Minimal repoint + conftest guard + submodule-side pytest *(Recommended)*
+### Approach 1: Repoint + two-layer guard + self-contained submodule pytest *(Recommended)*
 
 **Description**: `tests/conftest.py` resolves `personas_dir` to
-`REPO_ROOT / "tests" / "fixtures" / "personas"`. Private-content assertions in
-public tests are rewritten against fixture values. Persona-specific integration
-tests (the ones that genuinely validate the real submodule's YAML shape) move
-to `personas/personal/tests/` with their own `pyproject.toml` (pytest + PyYAML)
-and no import from `src/assistant/*`. A `pytest_collection_modifyitems` hook in
-`tests/conftest.py` inspects each collected test file's source and fails if it
-references `personas/(personal|work)/` paths or private-content strings outside
-the allow-list.
+`REPO_ROOT / "tests" / "fixtures" / "personas"`. Public tests are scrubbed of
+any reference to real-submodule content and rewritten against fixture-defined
+values (including a `FIXTURE_PERSONA_SENTINEL` marker for end-to-end
+composition coverage). Persona-specific integration tests move to
+`personas/personal/tests/` with their own `pyproject.toml` (pytest + PyYAML,
+plus a `[tool.uv]` workspace boundary so `uv` does not reuse the parent
+venv) and no import from `src/assistant/*`. Self-containment is proven by a
+fresh-venv test run, not by `PYTHONPATH` tricks. A **two-layer** privacy
+guard is wired into `tests/conftest.py`:
+(1) a collection-time substring scan that rejects literal
+`personas/personal/` or `personas/work/` references in test files and
+conftests, and (2) a runtime filesystem guard (a pytest plugin patching
+`pathlib.Path.open`, `read_text`, `read_bytes`, and `builtins.open`) that
+rejects path-constructed reads into the same namespaces — closing the
+`Path("personas") / name / "x.yaml"` bypass that defeats substring-only
+matching.
 
 **Pros**:
 - Clean separation: public tests never need the submodule initialized
 - Submodule stays harness-agnostic — can be consumed by non-Python harnesses
+- Two-layer guard catches both literal and constructed-path leaks
 - Enforcement runs locally *and* in CI (single mechanism, single place)
 - Removes the CI populate step and its "keep in sync" maintenance burden
 - Matches the team's existing pytest ergonomics on both sides
 
 **Cons**:
-- Submodule grows a small `pyproject.toml` dev-dep section (pytest, PyYAML)
+- Layer 2 runtime guard monkey-patches `builtins.open` during pytest runs
+  (scoped to test lifecycle only; documented limitation for mmap / ctypes I/O)
+- Submodule grows a small `pyproject.toml` dev-dep + `[tool.uv]` block
 - Test writers must remember which conftest to target when touching either side
 
 **Effort**: S
@@ -93,12 +104,23 @@ integration tests run in CI against the fixture).
 - Single test tree is easier to navigate
 
 **Cons**:
-- **Leakage not actually fixed**: integration tests still live in the public
-  repo and still assert on private strings. Moving them to a subdirectory is
-  cosmetic; `git log` / `git blame` still show private content being asserted.
-- CI populate step + fixture sync burden persists
-- Submodule is not independently testable by a non-Python harness
-- Marker-gated tests are easy to forget about and decay
+- **Marker decay**: `@pytest.mark.integration` is trivially missed by new
+  contributors. A test added without the marker but asserting on private
+  content silently ships. Enforcement via a linter gate is possible but
+  reintroduces the complexity the marker was meant to avoid.
+- **Submodule stays harness-coupled**: the private repo still has no
+  independent test suite. A future non-Python harness (MS Agent Framework,
+  Go/Rust consumer) cannot validate the persona contract without re-
+  implementing the Python import path.
+- **CI populate step + fixture-sync burden persists**: every structural
+  change to the real submodule still requires a matching change to the
+  public fixture, and the divergence window (local passing / CI failing,
+  or vice versa) remains open.
+- **Integration tests still live in public `git log`**: while both Approach
+  1 and Approach 2 leave pre-change assertions in pre-change history, only
+  Approach 1 moves *new* private-coupled tests out of the public repo
+  going forward. Approach 2 keeps the public-repo history accumulating
+  private assertions under a differently-named directory.
 
 **Effort**: S
 
@@ -125,27 +147,64 @@ schema shape) — never on content.
 
 ## Selected Approach
 
-**Approach 1** — repoint + guard + submodule-side pytest.
+**Approach 1** — repoint + two-layer guard + self-contained submodule
+pytest.
 
-Confirmed during discovery (Gate 1, 2026-04-13):
+Confirmed during discovery (Gate 1, 2026-04-13) and refined by Round 1
+multi-reviewer convergence (also 2026-04-13):
 
-- **Enforcement mechanism**: pytest conftest collection hook (runs locally
-  *and* in CI; single enforcement point).
-- **Submodule toolchain**: pytest with a minimal `pyproject.toml` in
-  `personas/personal/` declaring pytest + PyYAML as dev deps.
-- **Scope**: covers both `personas/personal/` *and* `personas/work/` from day
-  one, future-proofing the guard for P6 (`work-persona-config`) even though
-  `personas/work/` is not yet populated.
+- **Enforcement mechanism**: two layers wired into pytest via
+  `tests/conftest.py`. Layer 1 is a collection-time substring scan; Layer 2
+  is a runtime filesystem guard that patches `Path.open` / `read_text` /
+  `read_bytes` / `builtins.open` to reject reads under
+  `personas/<forbidden-name>/`. Both layers read from a single deny-list
+  config in `tests/_privacy_guard_config.py`.
+- **Submodule toolchain**: pytest with a `pyproject.toml` in
+  `personas/personal/` declaring pytest + PyYAML as dev deps, plus a
+  `[tool.uv]` block declaring the directory as a non-package with empty
+  workspace members so `uv` does not reuse the parent venv.
+- **Self-containment proof**: a fresh-venv test run in
+  `scripts/verify-submodule-standalone.sh`, plus a positive runtime
+  assertion that `importlib.import_module("assistant")` raises
+  `ImportError` inside the submodule suite.
+- **Scope**: covers both `personas/personal/` *and* `personas/work/` from
+  day one, future-proofing for P6 (`work-persona-config`).
 - **CI cleanup**: the `populate personas/personal from test fixture` step
   introduced in `76a313e` is **removed** — the conftest repoint makes it
-  redundant.
+  redundant. A new workflow-hygiene test
+  (`tests/test_ci_workflow_hygiene.py`) prevents future workflows from
+  silently re-introducing the dependency.
+- **Cross-repo push**: a dedicated `scripts/push-with-submodule.sh` wrapper
+  handles the dual-commit sequence (submodule push → parent gitlink
+  update) atomically with a documented recovery story for partial-failure
+  states.
 
 Approaches 2 and 3 are not selected:
 
-- **Approach 2 (marker-based dual-mode)** — does not actually fix leakage;
-  private strings remain in the public repo's `git log`/`git blame` under a
-  different directory. Cosmetic, not structural.
+- **Approach 2 (marker-based dual-mode)** — markers decay, the submodule
+  stays harness-coupled, and the CI populate-step / fixture-sync burden
+  persists. See the approach's Cons section above for the full
+  (Round-1-corrected) reasoning.
 - **Approach 3 (env-var placeholders)** — over-engineered. Personas are
   private, not secret; refactoring every consumer of `PersonaRegistry` and
   `RoleRegistry` to load prompts from env vars is disproportionate to the
   problem.
+
+### Changes from Round 1 review
+
+- **Dropped**: the `FORBIDDEN_CONTENT_STRINGS` deny-list. Cross-confirmed
+  by three reviewers: the strings the public repo can enumerate are the
+  same strings that exist in the public fixture, so a content-based
+  deny-list is incoherent. The path-based check is the full closure.
+- **Added**: the Layer-2 runtime filesystem guard, the fresh-venv
+  submodule-isolation proof, `[tool.uv]` workspace boundary, workflow-
+  hygiene regression test, atomic push script, `ALLOW_STANDALONE_SUBMODULE_SKIP`
+  opt-in for submodule standalone runs, and a fixture-sentinel-based
+  replacement for the lost end-to-end composition test.
+- **Reordered**: Phase 2 scrubs public tests *before* enabling the guard,
+  otherwise the guard would fail collection on the unscrubbed baseline.
+- **Tightened**: work-package scopes, dependencies, and constraints to
+  close routing gaps (`wp-integration` now declares
+  `requires_private_repo_write`; `wp-ci-cleanup` now depends on
+  `wp-public-tests`; `wp-integration` deny-lists submodule content so it
+  cannot accidentally write there).

--- a/openspec/changes/test-privacy-boundary/session-log.md
+++ b/openspec/changes/test-privacy-boundary/session-log.md
@@ -424,3 +424,49 @@ fixture files updated), wp-submodule-tests (6 tasks + script authoring,
 wp-ci-cleanup (3 tasks, 3 files — 1 workflow + 2 hygiene tests) and
 wp-integration (quality gates). Net diff: ~30 files, ~2k LOC including
 spec/plan artifacts and test code.
+
+---
+
+## Phase: Validation (2026-04-13)
+
+**Agent**: claude-opus-4-6 (main + 1 spec-audit subagent) | **Session**: N/A
+
+### Decisions
+
+1. **Skipped non-applicable phases.** Deploy / Smoke / Security / E2E /
+   Gen-Eval / Log-Analysis / Architecture phases do not apply to a
+   test-infrastructure feature with no HTTP API, no new dependencies,
+   and no architecture-graph artifacts in this repo. The applicable
+   phases are Spec Compliance, Work-Package Evidence, and CI/CD Status.
+
+2. **Spec audit found 14/14 scenarios passing** — dispatched a
+   subagent to verify every SHALL/MUST scenario in
+   `specs/test-privacy-boundary/spec.md` against the actual
+   implementation code. No scenario is unimplemented, none is partial.
+
+3. **Identified 5 spec-drift items to address during `/cleanup-feature`
+   spec-sync.** The most material is the `ASSISTANT_PERSONAS_DIR`
+   env-var contract: it's implemented, unit-tested (6 tests in
+   `test_env_var_contract.py`), and documented in `docs/gotchas.md`
+   G6 — but not declared as a SHALL in `spec.md`. Other drift items
+   cover subprocess kwarg coverage broader than the spec, Layer 1
+   scan exclusions, submodule parents[3] vs parents[2] wording, and
+   the `push-with-submodule.sh` helper script. None represent missing
+   implementation; all are cases where implementation is stricter
+   than the spec and should be codified.
+
+4. **CI is green on PR #2** (`Lint + typecheck + test` passed in 45s).
+   Confirms the test suite runs cleanly in a fresh CI environment
+   without the private submodule cloned — proves goal G1 at the
+   deployment level, not just via the local
+   `verify-public-tests-standalone.sh` script.
+
+### Context
+
+Validation phase confirmed the feature is ready to merge. 14/14 spec
+scenarios pass, 126 parent-repo tests green, submodule standalone
+proof green (9/9 in fresh venv), CI green on the open PR, no
+regressions or waivers. Full audit JSON produced by the spec-compliance
+subagent; per-scenario evidence captured in `validation-report.md`.
+Remaining work is spec-sync during `/cleanup-feature` to absorb the 5
+drift items.

--- a/openspec/changes/test-privacy-boundary/session-log.md
+++ b/openspec/changes/test-privacy-boundary/session-log.md
@@ -207,3 +207,104 @@ reviewers with distinct mandates) rather than true cross-vendor
 convergence, because `agents.yaml` is not scaffolded in this repo (P7
 territory). The convergence pattern (independent perspectives, synthesis,
 inline fix) was preserved even without vendor diversity.
+
+---
+
+## Phase: Plan Review Round 2 (2026-04-13)
+
+**Agent**: claude-opus-4-6 (2 parallel reviewer subagents) | **Session**: N/A
+
+### Summary
+
+Two reviewers — a convergence verifier (checking Round 1 fix adequacy)
+and a fresh adversarial pass (attacking the revised design) — produced
+10 findings. The verifier confirmed all 20 Round 1 BLOCKING+MAJOR
+findings RESOLVED or SUPERSEDED. The adversarial pass raised 1 BLOCKING
++ 5 MAJOR new findings, and the verifier raised 2 MAJOR clarifications.
+All 10 were mechanical cleanups on the fundamentally correct Round-1
+design; no design-level re-architecture needed.
+
+### New findings resolved in Round 3 fix
+
+- **B-N1 (BLOCKING) — subprocess bypass**: Layer 2 in-process patches
+  miss `subprocess.run(['cat', forbidden_path])`. **Fix**: extended
+  Layer 2 to patch `subprocess.Popen.__init__` (scans argv elements).
+- **B-N2 (MAJOR) — low-level I/O gap**: `os.open`, `io.FileIO`,
+  `codecs.open` bypass the patches. **Fix**: patch `os.open` as the
+  canonical syscall choke point (covers all the higher-level wrappers).
+- **B-N3 (MAJOR) — push script orphaned**: no task authored
+  `scripts/push-with-submodule.sh` though it was referenced by 5.3a/5.3b.
+  **Fix**: added task 5.0 with an explicit exit-code contract (exit 47
+  for partial-failure).
+- **B-N4 (MAJOR) — hygiene test self-trips**: `tests/test_ci_workflow_hygiene.py`
+  must contain `personas/personal/` as part of its grep pattern; Layer 1
+  would reject it. **Fix**: files use dynamic needle construction from
+  `FORBIDDEN_PATH_NAMES`; also added to Layer 1 exclusion list
+  (defence-in-depth).
+- **B-N5 (MAJOR) — PyPI package collision**: `assistant` exists as an
+  unrelated PyPI package; positive-import assertion could fail
+  spuriously. **Fix**: assertion now imports `assistant.core.persona`
+  (qualified path, won't collide).
+- **B-N6 (MAJOR) — parent workspace forward-compat**: if parent
+  pyproject later adds `[tool.uv.workspace] members = ['personas/*']`,
+  the submodule's own `workspace.members = []` cannot veto inclusion.
+  **Fix**: added `tests/test_workspace_hygiene.py` to assert the parent
+  does NOT declare `personas/*` as a workspace member.
+- **B-N7 (MINOR) — pytest rootdir ambiguity**: the fresh-venv proof
+  script ran pytest from parent repo root; parent's plugins could load.
+  **Fix**: script now `cd`s to `personas/personal/` before invoking
+  pytest with `--rootdir=.` and `--override-ini='addopts='`.
+- **B-N8 (MINOR) — plugin install silent failure**: if a future CPython
+  refuses Python-level rebinding of `Path.open`, the patches silently
+  fail to install and Layer 2 is disabled. **Fix**: added plugin
+  self-probe at `pytest_configure` that fails the session if the canary
+  does not raise.
+- **A-N1 (MAJOR) — task 5.4 self-contradiction**: task said "subsumed
+  by 5.3b" but was listed as a required task. **Fix**: 5.3b pushes the
+  parent branch; 5.4 opens the PR via `gh pr create`. Unambiguous.
+- **A-N2 (MAJOR) — 5.3-alt trigger ambiguity**: unclear whether
+  dispatch-time or runtime triggered. **Fix**: documented as an explicit
+  dual contract — dispatch-time quarantine driven by
+  `requires_private_repo_write` constraint, PLUS runtime exit-code-47
+  fallback if 5.3a fails after dispatch.
+
+### Task/package structure changes
+
+- Added task 5.0 (push-script authoring), task 4.4 renamed from
+  generic workflow-hygiene to hygiene test with dynamic-needle
+  construction, task 4.5 added for parent-workspace hygiene. Tasks 4.4
+  and 4.5 moved from wp-public-tests to wp-ci-cleanup so their RUN
+  happens after 4.1 (populate-step removal). wp-ci-cleanup now also
+  writes `tests/test_ci_workflow_hygiene.py` and
+  `tests/test_workspace_hygiene.py` (expanded write_allow; deny list
+  adjusted to exclude the specific named files from the tests/ deny).
+
+### Convergence verdict
+
+All Round 1 findings RESOLVED or SUPERSEDED; all Round 2 findings
+addressed inline. The plan is coherent and ready for implementation.
+Round 3 was fix-only (no new review pass) because the Round 2 findings
+were mechanical and each had a clear, targeted fix; a third round
+would be diminishing returns. Explicit documentation of remaining
+out-of-coverage surface (mmap, ctypes, os.system on Windows,
+deliberately-split subprocess argv) is captured in design R2.
+
+### Trade-offs
+
+- Accepted the Layer-2 patch surface growth (now 6 entry points
+  including subprocess) as the honest price of closing B-N1's bypass
+  class. The plugin is larger but still under ~200 lines.
+- Accepted the `wp-ci-cleanup` package's expanded scope to own the two
+  hygiene tests rather than splitting them into a new package. Cleaner
+  dispatcher DAG vs. stricter single-responsibility.
+
+### Open Questions
+
+- [ ] Does patching `subprocess.Popen.__init__` interfere with
+  pytest-xdist worker spawning? Worth surfacing during IMPLEMENT if
+  issues appear; fallback is to scope the subprocess patch to test
+  invocations only (not pytest-internal subprocess).
+- [ ] Does `os.open` patching interfere with pytest's own file-based
+  fixtures (tmp_path, capsys captures)? Theoretically no (those
+  paths don't match `personas/<name>/`), but verify during 2.13
+  implementation.

--- a/openspec/changes/test-privacy-boundary/session-log.md
+++ b/openspec/changes/test-privacy-boundary/session-log.md
@@ -70,3 +70,140 @@ from leaking through the public test suite. Artifact outputs cover proposal,
 design, spec delta, tasks, contracts stub, and work packages. openspec
 validate --strict passes. Coordinator registration returned HTTP 403 on the
 local profile API key; recorded as a permissions degradation, not a blocker.
+
+---
+
+## Phase: Plan Review Round 1 (2026-04-13)
+
+**Agent**: claude-opus-4-6 (3 parallel reviewer subagents) | **Session**: N/A
+
+### Summary
+
+Three independent reviewers (architecture/spec, adversarial, implementation
+feasibility) produced 27 total findings: 7 BLOCKING, 13 MAJOR, 7 MINOR/NIT.
+Cross-reviewer agreement on three foundational issues triggered a design-
+level rewrite rather than a mechanical patch.
+
+### Convergent findings (cross-reviewer confirmation)
+
+- **Content-string deny-list is misframed** (I2 + A2 + A9). The strings
+  "Personal Persona Context" and "Personal Context Additions" already
+  exist in the public fixture; the deny-list would block legitimate
+  assertions without preventing any actual leak. **Action**: removed the
+  content deny-list entirely; path-based enforcement becomes the sole
+  authoritative signal (now NG5). The guard's failure-message policy
+  also updated to avoid echoing private payloads into CI logs.
+
+- **Substring path-matching has a Copilot-friendly bypass** (A2). The
+  idiom `Path("personas") / name / "x.yaml"` produces no matching
+  substring. **Action**: added Layer 2 — a runtime filesystem guard as a
+  pytest plugin that patches `Path.open`, `read_text`, `read_bytes`, and
+  `builtins.open` to reject reads under `personas/<forbidden-name>/`.
+  Design D1 rewritten to describe the two-layer architecture.
+
+- **Submodule self-containment not verifiable as drafted** (A1).
+  `uv run pytest` from inside the submodule reuses the parent venv where
+  `assistant` IS importable; `PYTHONPATH=/dev/null` has no effect on
+  installed packages; the grep misses `importlib.import_module` and
+  `__import__`. **Action**: D4 rewritten to require (a) `[tool.uv]`
+  workspace boundary in the submodule pyproject, (b) a fresh-venv
+  standalone-proof in `scripts/verify-submodule-standalone.sh`, and
+  (c) a positive runtime assertion that `import assistant` raises
+  ImportError.
+
+### Other BLOCKING fixes
+
+- **Phase 2 ordering was circular** (I1): guard implementation preceded the
+  scrub of existing forbidden strings, so the guard's own verification
+  runs would fail collection. Phase 2 reordered: scrub 2.4-2.8 precedes
+  guard implementation 2.10-2.14.
+- **Root pytest does not run submodule tests** (F1): `pyproject.toml`
+  pins `testpaths = ["tests"]`. Task 5.2 split into 5.2a (root pytest)
+  and 5.2b (dedicated script runs submodule suite).
+- **wp-public-tests deny blocks its own verification** (F2): deny on
+  `personas/personal/**` conflicted with task 2.9's submodule manipulation.
+  Task 2.9 rewritten to use `git submodule deinit`/`update --init` via a
+  `trap`-protected script (I5), and the deny narrowed to specific paths
+  that wp-public-tests doesn't legitimately touch.
+- **Guard scope ambiguity** (A3, A4): scope now explicitly includes
+  `tests/**/conftest.py`, excludes `tests/_privacy_guard_config.py` and
+  `_privacy_guard_plugin.py`, and the `tests/fixtures/` allow-list is
+  narrowed to data-file types (D8).
+
+### Other MAJOR fixes
+
+- **Lost compose_system_prompt end-to-end coverage** (F4): added task 2.3
+  (fixture-sentinel-based integration test) and task 2.1 (add sentinel
+  string to fixture).
+- **wp-integration missing `requires_private_repo_write`** (F5, I3):
+  added the constraint; task 5.3 split into 5.3a (submodule push, lives
+  in wp-submodule-tests) and 5.3b (parent gitlink update, lives in
+  wp-integration); added 5.3-alt fallback for missing-credential case.
+- **Cross-package dep hidden** (I4): wp-docs-ci split into wp-docs
+  (parallel) and wp-ci-cleanup (depends on wp-public-tests).
+- **Pytester registration missing** (I6): task 2.11 switched to
+  subprocess-based testing, sidestepping the plugin-registration issue.
+- **Graphiti env-key coverage gap** (I7): task 3.1 now enumerates three
+  specific env-reference checks.
+- **Submodule push atomicity** (A8): added `scripts/push-with-submodule.sh`
+  as the documented atomic wrapper.
+- **Standalone-mode silent skip** (A6): now requires explicit
+  `ALLOW_STANDALONE_SUBMODULE_SKIP=1` opt-in; defaults to pytest.fail.
+- **CI workflow hygiene regression risk** (A7): added task 4.4
+  (`tests/test_ci_workflow_hygiene.py`) as a guard against future
+  workflows re-introducing the populate-dependency.
+- **wp-integration write_allow too broad** (I8): tightened to
+  `openspec/changes/**` and `.gitmodules`; deny-listed submodule contents.
+- **Approach 2 rejection rationale** (F6): rewritten with stronger
+  reasons (marker decay, harness coupling, persistent CI burden).
+
+### Decisions
+
+- Accepted the complexity cost of the Layer-2 runtime guard (monkey-
+  patching `builtins.open`) because the Copilot-friendly bypass in A2 is
+  a realistic threat, not an adversarial one.
+- Accepted the submodule's `[tool.uv]` workspace-boundary requirement as
+  a one-time setup cost for an otherwise-unprovable isolation claim.
+- Accepted the task count growth (from 22 to 27) as a trade-off for TDD
+  ordering clarity and explicit scope coverage.
+- Reaffirmed NG5 (no content-string deny-list) — the public repo cannot
+  enumerate private content, and trying to is a category error.
+
+### Alternatives Considered (Round 1)
+
+- Keeping the substring-only guard and documenting bypasses as known
+  limitations — rejected because the documented bypass (A2) is a
+  Copilot-default idiom, not an adversarial edge case.
+- Keeping the content-string deny-list with a parity test between fixture
+  and real submodule — rejected because that parity test would itself be
+  the private-content coupling we're trying to eliminate.
+- AST-level scanning instead of runtime filesystem patching — deferred;
+  the runtime FS guard is strictly more powerful (catches any I/O path,
+  not just textual patterns) and simpler to implement.
+
+### Open Questions
+
+- [ ] Does the `builtins.open` patch interact badly with any
+  pytest-asyncio fixture initialization order? Task 2.13 will surface
+  this during implementation; if issues appear, fallback is to patch
+  only `pathlib.*` and accept the `open()` bypass as Layer-1-only.
+- [ ] `scripts/push-with-submodule.sh` — does the implementer create it
+  from scratch, or is there an existing pattern in `.claude/skills/` to
+  reuse? Task 5.3a/5.3b should invoke it, wherever it ends up living.
+
+### Trade-offs
+
+- Accepted a larger plan (5 files grew by ~900 insertions) because Round
+  1 surfaced real correctness gaps, not speculative polish.
+- Accepted two new scripts (`verify-public-tests-standalone.sh`,
+  `verify-submodule-standalone.sh`, `push-with-submodule.sh`) over
+  inlining the verification logic into tasks — the scripts are
+  reusable, trap-guarded, and keep tasks.md readable.
+
+### Context
+
+Round 1 review used parallel subagent dispatch (three independent
+reviewers with distinct mandates) rather than true cross-vendor
+convergence, because `agents.yaml` is not scaffolded in this repo (P7
+territory). The convergence pattern (independent perspectives, synthesis,
+inline fix) was preserved even without vendor diversity.

--- a/openspec/changes/test-privacy-boundary/session-log.md
+++ b/openspec/changes/test-privacy-boundary/session-log.md
@@ -308,3 +308,119 @@ deliberately-split subprocess argv) is captured in design R2.
   fixtures (tmp_path, capsys captures)? Theoretically no (those
   paths don't match `personas/<name>/`), but verify during 2.13
   implementation.
+
+---
+
+## Phase: Implementation (2026-04-13)
+
+**Agent**: claude-opus-4-6 (main session + 3 parallel work-package subagents) | **Session**: N/A
+
+### Summary
+
+All 27 tasks executed across 5 work packages. Dispatched 3 parallel
+subagents for `wp-public-tests`, `wp-submodule-tests`, `wp-docs`; main
+session executed `wp-ci-cleanup` (CI workflow edit + 2 hygiene tests)
+and `wp-integration` (validations + quality gates). One scope expansion
+was required during execution (see Deviations).
+
+### Decisions
+
+1. **Added `ASSISTANT_PERSONAS_DIR` env-var to `PersonaRegistry` and
+   `RoleRegistry`.** The CLI in-process tests invoke `PersonaRegistry()`
+   with the default `Path("personas")`, which Layer 2 correctly rejects.
+   Options: (a) add `--personas-dir` CLI flag + test-side argv plumbing,
+   (b) monkey-patch the class defaults in conftest, (c) add an env var
+   the registries honor. Chose (c) — one-line change in each registry,
+   no CLI API surface growth, backward-compatible (unset env means
+   default `Path("personas")`). `tests/conftest.py` sets the env at
+   module-top via `os.environ.setdefault` so it's live for the whole
+   session.
+
+2. **Subprocess `wp-submodule-tests` output was wiped and reconstructed
+   inline.** My running of `scripts/verify-public-tests-standalone.sh`
+   did `git submodule deinit -f && git submodule update --init`, which
+   restored the submodule to its remote SHA and wiped the uncommitted
+   submodule files the subagent had written. Reconstructed the same 5
+   files (pyproject.toml + 4 test files) in the main session from the
+   subagent's report. Lesson: run the submodule-deinit standalone proof
+   BEFORE any writes to the submodule, not after.
+
+3. **`_PrivacyBoundaryViolation(pytest.UsageError)` suppressed with
+   `# type: ignore[misc]`.** pytest marks `UsageError` as `@final` in
+   its type stubs, but at runtime subclassing works. Accept the
+   suppression to preserve the "UsageError subclass" contract that
+   pytest's session-fail machinery recognizes.
+
+### Alternatives Considered
+
+- Moving task 2.9's public-test standalone verification to wp-integration
+  (later in the DAG, after all submodule writes landed): rejected
+  because 2.9's verification is scoped to wp-public-tests' own success
+  criterion; running it there is correct. The mistake was my execution
+  order, not the DAG design.
+- Adding a pytest `monkeypatch` autouse fixture to redirect
+  `PersonaRegistry.__init__` defaults at test-session scope: rejected
+  in favor of the env-var approach because the CLI tests spin up fresh
+  `PersonaRegistry` instances inside `click`'s runner invocation and
+  the fixture would need to be imported/used by every such test.
+
+### Trade-offs
+
+- Accepted the env-var approach expanding feature scope into `src/`
+  (2 files: `persona.py`, `role.py`). This was not in the original plan,
+  but the plan's "repoint personas_dir at fixtures" implicitly required
+  a way for the CLI's in-process registry to honor that repoint. The
+  change is small (~5 lines per file) and backward-compatible.
+- Accepted reconstructing the submodule files in the main session
+  rather than re-dispatching the subagent. Faster and keeps the context
+  within the main thread; subagent already reported what it wrote.
+
+### Deviations from plan
+
+- **Added files not listed in any task**: `src/assistant/core/persona.py`
+  and `src/assistant/core/role.py` gained ~5 lines each to honor
+  `ASSISTANT_PERSONAS_DIR`. This is a scope expansion required to make
+  the CLI tests pass. Should have been captured as a new task 2.X in
+  the plan but emerged from running the actual implementation.
+- **Submodule file authoring order**: task 2.9 (public tests without
+  submodule) landed before task 3.1-3.6 files were durably stored in
+  the submodule mount. Re-authored 3.1-3.5 + pyproject inline. Task
+  outputs are correct; the order-of-execution gap is documented here.
+- **Minor `test_privacy_guard.py` cleanup**: ruff auto-fix removed an
+  unused `pytest` import. No semantic change.
+
+### Verification evidence
+
+- `uv run pytest tests/` — **112 passed**, 0 failed.
+- `uv run mypy src tests` — **Success: no issues found in 37 source files**.
+- `uv run ruff check .` — **All checks passed**.
+- `bash scripts/verify-public-tests-standalone.sh` — **112 passed**
+  with personas/personal deinit'd (proves G1: public suite runs without
+  submodule).
+- `bash scripts/verify-submodule-standalone.sh` — **9 passed** in a
+  fresh `/tmp/spb-venv-$$` venv with only pytest+pyyaml installed,
+  rootdir resolved to submodule's own pyproject, positive
+  `importlib.import_module("assistant.core.persona")` raises ImportError.
+- `openspec validate test-privacy-boundary --strict` — **passes**.
+
+### Open Questions
+
+- [ ] The `ASSISTANT_PERSONAS_DIR` env-var scope expansion needs to be
+  folded into the spec as an implementation detail (not a new
+  requirement — it just makes the existing repoint requirement
+  testable). Deferred to spec-sync as part of `/cleanup-feature`.
+- [ ] Submodule's uncommitted files (pyproject.toml + tests/) need to
+  be committed inside the submodule's own repo and pushed to its
+  private remote before the parent can record the SHA bump. Will run
+  via `scripts/push-with-submodule.sh --submodule-only` in the PR
+  phase; requires private-repo credentials.
+
+### Context
+
+Full end-to-end implementation of the 5-package DAG. Parallel subagents
+for wp-public-tests (14 tasks, 4 files created + 6 files modified + 2
+fixture files updated), wp-submodule-tests (6 tasks + script authoring,
+7 files), wp-docs (2 tasks, 2 files); main session handled
+wp-ci-cleanup (3 tasks, 3 files — 1 workflow + 2 hygiene tests) and
+wp-integration (quality gates). Net diff: ~30 files, ~2k LOC including
+spec/plan artifacts and test code.

--- a/openspec/changes/test-privacy-boundary/session-log.md
+++ b/openspec/changes/test-privacy-boundary/session-log.md
@@ -1,0 +1,72 @@
+# Session Log — test-privacy-boundary
+
+---
+
+## Phase: Plan (2026-04-13)
+
+**Agent**: claude-opus-4-6 (main / autopilot) | **Session**: N/A
+
+### Decisions
+
+1. Selected Approach 1 — repoint fixture root, add a conftest guard, and
+   relocate persona-specific tests into the submodule. This matches the user
+   requirement that the persona repo stay harness-agnostic so it can later be
+   consumed by a non-Python harness.
+
+2. D1. Enforce the boundary at pytest collection time. A hook inspects each
+   collected test file and fails the session before any test body runs.
+   Substring matching is intentional; AST inspection is out of scope.
+
+3. D2. Deny-lists live as module constants near the top of conftest.py, so
+   the rules are discoverable by every test author without a separate config
+   file.
+
+4. D3. Submodule tests parse YAML directly via yaml.safe_load. They do not
+   import from the parent harness. This preserves the self-contained goal.
+
+5. Scope covers both the personal persona and the future work persona.
+   Guard deny-list includes both path prefixes on day one, even though the
+   work submodule is not yet populated.
+
+6. D6. Remove the CI populate step rather than keep it as defense in depth.
+   Keeping it creates a silent-divergence trap between fixture content and
+   real submodule content.
+
+### Alternatives Considered
+
+- Approach 2, marker-based dual-mode — rejected as cosmetic. Moving private
+  strings under tests/integration still leaves them in the public repo's
+  git log, so the leak is not actually fixed.
+- Approach 3, env-var placeholders — rejected as over-engineered. Personas
+  are private, not secret; refactoring every consumer of the registries to
+  load content from env vars is disproportionate.
+- CI lint instead of conftest hook — rejected in favor of the hook so local
+  feedback is fast.
+- Keeping the CI populate step as a safety net — rejected per D6.
+
+### Trade-offs
+
+- Accepted substring matching over AST inspection because the threat model
+  is accidental leakage, not adversarial circumvention.
+- Accepted a two-dep pyproject addition (pytest, pyyaml) in the submodule to
+  preserve self-containment. Coupling the submodule to the parent harness
+  would cost more in the long run.
+- Accepted that standalone submodule execution may skip the base-role
+  existence check when the parent roles dir is not reachable. Acceptable
+  because strong cross-repo invariants only hold in a parent checkout.
+
+### Open Questions
+
+- [ ] How does /implement-feature route the submodule-tests package to an
+  agent with private-repo write access? work-packages.yaml uses a
+  non-standard constraints.requires_private_repo_write flag.
+- [ ] Should a later change add a fixture-vs-submodule parity check, or keep
+  the two intentionally decoupled? Defer until drift is observed.
+
+### Context
+
+Goal of this phase was to scope a change that prevents private persona data
+from leaking through the public test suite. Artifact outputs cover proposal,
+design, spec delta, tasks, contracts stub, and work packages. openspec
+validate --strict passes. Coordinator registration returned HTTP 403 on the
+local profile API key; recorded as a permissions degradation, not a blocker.

--- a/openspec/changes/test-privacy-boundary/specs/test-privacy-boundary/spec.md
+++ b/openspec/changes/test-privacy-boundary/specs/test-privacy-boundary/spec.md
@@ -6,97 +6,193 @@
 
 Public test code under `tests/` SHALL load persona configuration exclusively
 from the fixture root at `tests/fixtures/personas/`, and SHALL NOT read from
-the submodule mount points under `personas/<name>/` at runtime.
+the submodule mount points under `personas/<name>/` at runtime, except for
+`personas/_template/`.
 
 #### Scenario: Public personas_dir fixture resolves to fixtures root
 
-- **WHEN** a public test in `tests/` consumes the `personas_dir` pytest fixture
+- **WHEN** a public test in `tests/` consumes the `personas_dir` pytest
+  fixture
 - **THEN** the fixture SHALL resolve to `<repo_root>/tests/fixtures/personas/`
 - **AND** it SHALL NOT resolve to `<repo_root>/personas/`
 
 #### Scenario: Public test suite passes without submodule content
 
-- **WHEN** the private submodule `personas/personal/` is uninitialized, empty,
-  or git-removed
+- **WHEN** the private submodule `personas/personal/` is uninitialized,
+  empty, or `git submodule deinit`-ed
 - **AND** `uv run pytest tests/` is invoked from the repository root
 - **THEN** the command SHALL exit with status 0
-- **AND** no collected test SHALL require `personas/personal/persona.yaml` (or
-  any file under `personas/<name>/` for any persona name) to exist
+- **AND** no collected test SHALL require `personas/personal/persona.yaml`
+  (or any file under `personas/<name>/` for any forbidden name) to exist
 
-### Requirement: Collection-time boundary guard
+### Requirement: Two-layer collection-time and runtime boundary guard
 
-A `pytest_collection_modifyitems` hook registered in `tests/conftest.py` SHALL
-inspect the source text of every collected public test file and fail the
-session if the file references private persona paths or known private-content
-strings.
+The test suite SHALL enforce the privacy boundary at two layers, both
+configured from a single deny-list module `tests/_privacy_guard_config.py`:
 
-#### Scenario: Guard rejects a forbidden path reference
+- **Layer 1 (collection-time substring scan)**: a
+  `pytest_collection_modifyitems` hook in `tests/conftest.py` SHALL inspect
+  the source text of every collected test file and every conftest under
+  `tests/`, and SHALL fail the session if any inspected file contains a
+  forbidden path substring outside the documented exclusion list.
+- **Layer 2 (runtime filesystem guard)**: a pytest plugin SHALL patch
+  `pathlib.Path.open`, `pathlib.Path.read_text`, `pathlib.Path.read_bytes`,
+  and `builtins.open` for the duration of test collection and execution,
+  and SHALL raise a `pytest.UsageError` subclass when any of these is
+  called with a path that resolves under `personas/<name>/` for `<name>` in
+  the forbidden-names list, with allow-listed exceptions for paths under
+  `tests/fixtures/` and `personas/_template/`.
 
-- **WHEN** a public test file under `tests/` (excluding `tests/fixtures/`)
-  contains the literal substring `personas/personal/` or `personas/work/` in
-  its source
-- **THEN** the pytest collection phase SHALL emit an error identifying the
-  violating file and the matched substring
+#### Scenario: Layer 1 rejects a literal forbidden path substring
+
+- **WHEN** a public test file under `tests/test_*.py` or
+  `tests/**/conftest.py` contains the literal substring
+  `personas/personal/` or `personas/work/` in its source
+- **AND** the file is not in the Layer 1 exclusion list
+- **THEN** the pytest collection phase SHALL fail with an error identifying
+  the violating file, the matched substring, and a remediation hint
 - **AND** the session SHALL exit with a non-zero status before any test body
   executes
 
-#### Scenario: Guard rejects a private-content string
-
-- **WHEN** a public test file under `tests/` (excluding `tests/fixtures/`)
-  contains any string in the configured private-content deny-list (e.g.
-  `"Personal Persona Context"`, `"Personal Context Additions"`)
-- **THEN** the collection phase SHALL fail with a message naming the leaked
-  string and the violating file
-- **AND** remediation guidance SHALL direct the author to either move the test
-  into the persona's submodule suite or rewrite it against fixture values
-
-#### Scenario: Guard allows template and fixture references
+#### Scenario: Layer 1 allows template and fixture references
 
 - **WHEN** a test file references `personas/_template/` or paths under
   `tests/fixtures/`
-- **THEN** the collection guard SHALL NOT raise an error for those references
+- **THEN** Layer 1 SHALL NOT raise an error for those references
 
-#### Scenario: Guard covers both personal and work personas
+#### Scenario: Layer 1 covers both personal and work persona names
 
 - **WHEN** the guard is configured
-- **THEN** its deny-list SHALL include both `personas/personal/` and
-  `personas/work/` path prefixes
-- **AND** the guard SHALL reject references to either, regardless of whether
-  the corresponding submodule is currently populated
+- **THEN** the deny-list `FORBIDDEN_PATH_NAMES` SHALL include both
+  `"personal"` and `"work"`
+- **AND** Layer 1 SHALL reject substrings of the form `personas/personal/`
+  or `personas/work/`, regardless of whether the corresponding submodule
+  is currently populated
+
+#### Scenario: Layer 2 rejects a runtime-constructed forbidden read
+
+- **WHEN** any test code reads a file using `Path.open`, `Path.read_text`,
+  `Path.read_bytes`, or `builtins.open`
+- **AND** the resolved path is under `personas/<name>/` for `<name>` in
+  `FORBIDDEN_PATH_NAMES`
+- **AND** the resolved path is not under any prefix in
+  `ALLOWED_READ_PREFIXES`
+- **THEN** the call SHALL raise `_PrivacyBoundaryViolation`
+- **AND** the test SHALL fail with a stack trace identifying the test file,
+  the call site, and the resolved path
+
+#### Scenario: Layer 2 permits allow-listed reads
+
+- **WHEN** any test code reads a file under `tests/fixtures/` or
+  `personas/_template/`
+- **THEN** Layer 2 SHALL allow the read without raising
+
+#### Scenario: Guard scope excludes its own implementation files
+
+- **WHEN** Layer 1 inspects files under `tests/`
+- **THEN** it SHALL skip `tests/_privacy_guard_config.py` and
+  `tests/_privacy_guard_plugin.py`
+- **AND** it SHALL skip files under `tests/fixtures/`
+
+#### Scenario: Guard failure messages do not echo private payloads
+
+- **WHEN** Layer 1 or Layer 2 emits a failure message
+- **THEN** the message SHALL identify the violating file path and the
+  matched deny-list entry by name
+- **AND** the message SHALL NOT include the violating path's *file
+  contents*, so failure logs do not become a private-data exfiltration
+  vector
 
 ### Requirement: Self-contained persona-submodule test suite
 
 Each persona submodule that ships tests SHALL contain a self-contained test
-suite that runs without importing any symbol from the main repo's
-`src/assistant/` package or the public `tests/` directory.
+suite that runs without `assistant` being importable, and the
+self-containment SHALL be verifiable by a fresh-venv proof.
 
-#### Scenario: Submodule tests run standalone
+#### Scenario: Submodule pyproject declares an isolated workspace
 
-- **WHEN** pytest is invoked from inside `personas/personal/` with that
-  submodule's dev dependencies installed (e.g. `uv run pytest` after
-  `uv sync` inside the submodule)
-- **THEN** the test suite SHALL collect and execute successfully without the
-  parent repo's `src/assistant/` package being importable
-- **AND** no test in `personas/personal/tests/` SHALL contain the import
-  statement `import assistant` or `from assistant` or `from src.assistant`
+- **WHEN** `personas/personal/pyproject.toml` is read
+- **THEN** it SHALL contain a `[tool.uv]` section declaring this directory
+  as a non-package and SHALL NOT include the parent project as a workspace
+  member
+- **AND** `uv run pytest` invoked from inside `personas/personal/` SHALL NOT
+  reuse the parent project's venv
+
+#### Scenario: Submodule tests assert assistant import fails at runtime
+
+- **WHEN** the submodule test suite runs in its isolated venv
+- **THEN** the suite SHALL contain a positive runtime check that calls
+  `importlib.import_module("assistant")` and asserts that the call raises
+  `ImportError`
+- **AND** the suite SHALL include a static check (grep or AST) that no
+  test file under `personas/personal/tests/` contains the strings
+  `import assistant`, `from assistant`, `from src.assistant`,
+  `__import__("assistant")`, or `importlib.import_module("assistant")`
+  outside the dedicated negative-import test
+
+#### Scenario: Standalone-proof verification uses a fresh venv
+
+- **WHEN** the standalone-proof step (task 3.6) runs
+- **THEN** it SHALL create a freshly-provisioned virtual environment that
+  does not have `assistant` installed
+- **AND** it SHALL install only `pytest` and `pyyaml` (per
+  `personas/personal/pyproject.toml`'s dev deps)
+- **AND** it SHALL invoke `pytest personas/personal/tests/` from that fresh
+  venv
+- **AND** the run SHALL exit with status 0
+- **AND** `PYTHONPATH=/dev/null` SHALL NOT be relied upon as proof of
+  isolation (it does not affect installed packages)
 
 #### Scenario: Submodule suite validates YAML shape
 
 - **WHEN** the submodule test suite runs
-- **THEN** it SHALL assert that `personas/personal/persona.yaml` contains the
-  required top-level keys (`name`, `display_name`, `database`, `auth`,
+- **THEN** it SHALL assert that `personas/personal/persona.yaml` contains
+  the required top-level keys (`name`, `display_name`, `database`, `auth`,
   `harnesses`, `default_role`)
-- **AND** it SHALL assert that `database.url_env`, `graphiti.url_env`, and all
-  `auth.config.*_env` values follow the `PERSONAL_*` prefix convention
+- **AND** it SHALL assert that `database.url_env` starts with `PERSONAL_`
+- **AND** it SHALL assert that `graphiti.url_env` starts with `PERSONAL_`
+  if the `graphiti` block is present (or assert the block's intentional
+  absence per the persona's documented contract)
+- **AND** it SHALL assert that every value of `auth.config.*_env` starts
+  with `PERSONAL_`
 - **AND** for each role override file under `personas/personal/roles/`, it
-  SHALL assert that a base role of the same name exists in the parent repo's
-  `roles/` directory (the parent `roles/` path is resolved relative to the
-  submodule mount via `../..`)
+  SHALL assert that a base role of the same name exists in the parent
+  repo's `roles/` directory, resolved via `parents[2] / "roles"`
 
-### Requirement: CI simplification
+#### Scenario: Standalone mode requires explicit opt-in
+
+- **WHEN** the role-override-existence check runs and the parent `roles/`
+  directory is not reachable from the submodule
+- **AND** the env var `ALLOW_STANDALONE_SUBMODULE_SKIP=1` is NOT set
+- **THEN** the test SHALL `pytest.fail` with a message naming the env var
+  required to bypass the cross-repo check
+- **WHEN** the env var IS set
+- **THEN** the test SHALL `pytest.skip` with a clearly-flagged message
+
+### Requirement: Replacement integration coverage for compose_system_prompt
+
+The public test suite SHALL retain end-to-end coverage of
+`compose_system_prompt` against a real persona+role load, using the public
+fixture data, so that the composition pipeline is exercised end-to-end
+without depending on the private submodule.
+
+#### Scenario: Fixture-based composition test asserts on a fixture sentinel
+
+- **WHEN** a public test in `tests/test_composition.py` calls
+  `compose_system_prompt(persona, role)` against a persona+role loaded from
+  `tests/fixtures/personas/`
+- **THEN** the composed prompt SHALL contain a fixture-defined sentinel
+  string that is unique to the fixture (e.g. `FIXTURE_PERSONA_SENTINEL`),
+  not a string sourced from any real submodule's content
+- **AND** the test SHALL assert on that sentinel, proving the composition
+  pipeline traverses persona → role → output correctly
+
+### Requirement: CI simplification and forward-compatible hygiene check
 
 The `.github/workflows/ci.yml` workflow SHALL NOT contain any step that
-populates, copies, or rsyncs content into `personas/<name>/`.
+populates, copies, or rsyncs content into `personas/<name>/`. A regression
+guard SHALL prevent future workflows from silently re-introducing such a
+dependency.
 
 #### Scenario: CI omits the populate-personas step
 
@@ -105,6 +201,16 @@ populates, copies, or rsyncs content into `personas/<name>/`.
   write files into `personas/personal/` or `personas/work/`
 - **AND** the `pytest` step SHALL succeed using only `tests/fixtures/personas/`
   as its persona data source
+
+#### Scenario: Workflow-hygiene test rejects future leakage paths
+
+- **WHEN** any file under `.github/workflows/` references `personas/personal/`
+  or `personas/work/`
+- **AND** the reference is not paired with an explicit
+  copy-from-`tests/fixtures/` step
+- **THEN** `tests/test_ci_workflow_hygiene.py` SHALL fail at collection or
+  run time with a message identifying the workflow file and the violating
+  reference
 
 ### Requirement: Documentation of the privacy boundary rule
 
@@ -115,14 +221,19 @@ The repository SHALL document the public-vs-private test rule in both
 
 - **WHEN** `CLAUDE.md` is read
 - **THEN** the "Conventions" section SHALL contain a bullet stating that
-  public tests use fixtures only and that persona-specific tests live in the
-  persona's private submodule and are self-contained
+  public tests use fixtures only and that persona-specific tests live in
+  the persona's private submodule and are self-contained
 
 #### Scenario: docs/gotchas.md records the failure mode
 
 - **WHEN** `docs/gotchas.md` is read
 - **THEN** a new gotcha entry SHALL describe the private-content leakage
-  failure mode (symptom: CI passes locally but private strings appear in
-  public test assertions; root cause: `personas_dir` was pointed at the real
-  submodule; fix: repoint to fixtures + rely on the conftest guard;
-  prevention: let the collection guard catch new violations)
+  failure mode (symptom: CI passes locally but private content appears in
+  public test code or assertions; root cause: `personas_dir` was pointed
+  at the real submodule, OR a runtime path was constructed via path-join
+  to bypass substring matching; fix: repoint to fixtures + rely on the
+  two-layer guard; prevention: the runtime FS guard + the workflow-hygiene
+  test catch both classes of regression)
+- **AND** a separate entry SHALL document the
+  `ALLOW_STANDALONE_SUBMODULE_SKIP=1` opt-in for submodule maintainers
+  running tests outside a parent checkout

--- a/openspec/changes/test-privacy-boundary/specs/test-privacy-boundary/spec.md
+++ b/openspec/changes/test-privacy-boundary/specs/test-privacy-boundary/spec.md
@@ -37,11 +37,18 @@ configured from a single deny-list module `tests/_privacy_guard_config.py`:
   forbidden path substring outside the documented exclusion list.
 - **Layer 2 (runtime filesystem guard)**: a pytest plugin SHALL patch
   `pathlib.Path.open`, `pathlib.Path.read_text`, `pathlib.Path.read_bytes`,
-  and `builtins.open` for the duration of test collection and execution,
-  and SHALL raise a `pytest.UsageError` subclass when any of these is
-  called with a path that resolves under `personas/<name>/` for `<name>` in
-  the forbidden-names list, with allow-listed exceptions for paths under
-  `tests/fixtures/` and `personas/_template/`.
+  `builtins.open`, `os.open`, and `subprocess.Popen.__init__` for the
+  duration of test collection and execution, and SHALL raise a
+  `pytest.UsageError` subclass when any of the file-opening entry points
+  is called with a path that resolves under `personas/<name>/` for
+  `<name>` in the forbidden-names list, or when a subprocess's argv
+  contains a substring matching a forbidden path prefix, with allow-listed
+  exceptions for paths under `tests/fixtures/` and `personas/_template/`.
+- **Layer 2 self-probe**: at plugin-install time (`pytest_configure`), the
+  plugin SHALL verify the patches are active by attempting a read of a
+  canary forbidden path and asserting `_PrivacyBoundaryViolation` is
+  raised. If the self-probe fails, the plugin SHALL fail the session via
+  `pytest.UsageError` before any test body runs.
 
 #### Scenario: Layer 1 rejects a literal forbidden path substring
 
@@ -72,7 +79,7 @@ configured from a single deny-list module `tests/_privacy_guard_config.py`:
 #### Scenario: Layer 2 rejects a runtime-constructed forbidden read
 
 - **WHEN** any test code reads a file using `Path.open`, `Path.read_text`,
-  `Path.read_bytes`, or `builtins.open`
+  `Path.read_bytes`, `builtins.open`, or `os.open`
 - **AND** the resolved path is under `personas/<name>/` for `<name>` in
   `FORBIDDEN_PATH_NAMES`
 - **AND** the resolved path is not under any prefix in
@@ -80,6 +87,28 @@ configured from a single deny-list module `tests/_privacy_guard_config.py`:
 - **THEN** the call SHALL raise `_PrivacyBoundaryViolation`
 - **AND** the test SHALL fail with a stack trace identifying the test file,
   the call site, and the resolved path
+
+#### Scenario: Layer 2 rejects a forbidden subprocess argv
+
+- **WHEN** any test code invokes `subprocess.Popen`, `subprocess.run`, or
+  any wrapper that constructs a subprocess
+- **AND** any element of the subprocess's `args` contains a substring of
+  the form `personas/<name>/` for `<name>` in `FORBIDDEN_PATH_NAMES`
+- **THEN** the call SHALL raise `_PrivacyBoundaryViolation` before the
+  subprocess is spawned
+- **AND** the failure message SHALL identify the test file, the
+  subprocess call site, and the matched argv element
+
+#### Scenario: Layer 2 self-probes after installation
+
+- **WHEN** pytest's `pytest_configure` hook finishes installing the
+  Layer 2 patches
+- **THEN** the plugin SHALL attempt a canary read of a path under
+  `personas/personal/` that is NOT allow-listed
+- **AND** the attempt SHALL raise `_PrivacyBoundaryViolation`
+- **AND** if the canary does NOT raise, the plugin SHALL fail the session
+  via `pytest.UsageError("Layer 2 privacy guard failed to install")`
+  before any test body runs
 
 #### Scenario: Layer 2 permits allow-listed reads
 
@@ -122,8 +151,10 @@ self-containment SHALL be verifiable by a fresh-venv proof.
 
 - **WHEN** the submodule test suite runs in its isolated venv
 - **THEN** the suite SHALL contain a positive runtime check that calls
-  `importlib.import_module("assistant")` and asserts that the call raises
-  `ImportError`
+  `importlib.import_module("assistant.core.persona")` — the qualified
+  submodule path that is distinctive to this project and will not
+  collide with the unrelated PyPI package named `assistant` — and
+  asserts that the call raises `ImportError`
 - **AND** the suite SHALL include a static check (grep or AST) that no
   test file under `personas/personal/tests/` contains the strings
   `import assistant`, `from assistant`, `from src.assistant`,
@@ -137,11 +168,27 @@ self-containment SHALL be verifiable by a fresh-venv proof.
   does not have `assistant` installed
 - **AND** it SHALL install only `pytest` and `pyyaml` (per
   `personas/personal/pyproject.toml`'s dev deps)
-- **AND** it SHALL invoke `pytest personas/personal/tests/` from that fresh
-  venv
+- **AND** it SHALL `cd` into `personas/personal/` before invoking pytest,
+  so the submodule's own `pyproject.toml` is pytest's rootdir and the
+  parent's `pytest_plugins` (privacy guard) are not loaded against
+  submodule tests
+- **AND** it SHALL invoke `pytest tests/` from inside the submodule using
+  the fresh venv's interpreter
 - **AND** the run SHALL exit with status 0
 - **AND** `PYTHONPATH=/dev/null` SHALL NOT be relied upon as proof of
   isolation (it does not affect installed packages)
+
+#### Scenario: Parent pyproject does not include submodule in a uv workspace
+
+- **WHEN** `tests/test_workspace_hygiene.py` runs
+- **THEN** it SHALL parse the parent repo's `pyproject.toml`
+- **AND** it SHALL assert that either (a) no `[tool.uv.workspace]`
+  section exists, or (b) if it does, `members` SHALL NOT contain any
+  glob that matches `personas/personal/` or `personas/work/` (e.g.
+  `personas/*`, `personas/**`)
+- **AND** this guards against a future dev-ergonomics change
+  accidentally drawing the submodule into the parent venv, which would
+  defeat the self-containment invariant
 
 #### Scenario: Submodule suite validates YAML shape
 

--- a/openspec/changes/test-privacy-boundary/specs/test-privacy-boundary/spec.md
+++ b/openspec/changes/test-privacy-boundary/specs/test-privacy-boundary/spec.md
@@ -1,0 +1,128 @@
+# test-privacy-boundary
+
+## ADDED Requirements
+
+### Requirement: Public test fixture root
+
+Public test code under `tests/` SHALL load persona configuration exclusively
+from the fixture root at `tests/fixtures/personas/`, and SHALL NOT read from
+the submodule mount points under `personas/<name>/` at runtime.
+
+#### Scenario: Public personas_dir fixture resolves to fixtures root
+
+- **WHEN** a public test in `tests/` consumes the `personas_dir` pytest fixture
+- **THEN** the fixture SHALL resolve to `<repo_root>/tests/fixtures/personas/`
+- **AND** it SHALL NOT resolve to `<repo_root>/personas/`
+
+#### Scenario: Public test suite passes without submodule content
+
+- **WHEN** the private submodule `personas/personal/` is uninitialized, empty,
+  or git-removed
+- **AND** `uv run pytest tests/` is invoked from the repository root
+- **THEN** the command SHALL exit with status 0
+- **AND** no collected test SHALL require `personas/personal/persona.yaml` (or
+  any file under `personas/<name>/` for any persona name) to exist
+
+### Requirement: Collection-time boundary guard
+
+A `pytest_collection_modifyitems` hook registered in `tests/conftest.py` SHALL
+inspect the source text of every collected public test file and fail the
+session if the file references private persona paths or known private-content
+strings.
+
+#### Scenario: Guard rejects a forbidden path reference
+
+- **WHEN** a public test file under `tests/` (excluding `tests/fixtures/`)
+  contains the literal substring `personas/personal/` or `personas/work/` in
+  its source
+- **THEN** the pytest collection phase SHALL emit an error identifying the
+  violating file and the matched substring
+- **AND** the session SHALL exit with a non-zero status before any test body
+  executes
+
+#### Scenario: Guard rejects a private-content string
+
+- **WHEN** a public test file under `tests/` (excluding `tests/fixtures/`)
+  contains any string in the configured private-content deny-list (e.g.
+  `"Personal Persona Context"`, `"Personal Context Additions"`)
+- **THEN** the collection phase SHALL fail with a message naming the leaked
+  string and the violating file
+- **AND** remediation guidance SHALL direct the author to either move the test
+  into the persona's submodule suite or rewrite it against fixture values
+
+#### Scenario: Guard allows template and fixture references
+
+- **WHEN** a test file references `personas/_template/` or paths under
+  `tests/fixtures/`
+- **THEN** the collection guard SHALL NOT raise an error for those references
+
+#### Scenario: Guard covers both personal and work personas
+
+- **WHEN** the guard is configured
+- **THEN** its deny-list SHALL include both `personas/personal/` and
+  `personas/work/` path prefixes
+- **AND** the guard SHALL reject references to either, regardless of whether
+  the corresponding submodule is currently populated
+
+### Requirement: Self-contained persona-submodule test suite
+
+Each persona submodule that ships tests SHALL contain a self-contained test
+suite that runs without importing any symbol from the main repo's
+`src/assistant/` package or the public `tests/` directory.
+
+#### Scenario: Submodule tests run standalone
+
+- **WHEN** pytest is invoked from inside `personas/personal/` with that
+  submodule's dev dependencies installed (e.g. `uv run pytest` after
+  `uv sync` inside the submodule)
+- **THEN** the test suite SHALL collect and execute successfully without the
+  parent repo's `src/assistant/` package being importable
+- **AND** no test in `personas/personal/tests/` SHALL contain the import
+  statement `import assistant` or `from assistant` or `from src.assistant`
+
+#### Scenario: Submodule suite validates YAML shape
+
+- **WHEN** the submodule test suite runs
+- **THEN** it SHALL assert that `personas/personal/persona.yaml` contains the
+  required top-level keys (`name`, `display_name`, `database`, `auth`,
+  `harnesses`, `default_role`)
+- **AND** it SHALL assert that `database.url_env`, `graphiti.url_env`, and all
+  `auth.config.*_env` values follow the `PERSONAL_*` prefix convention
+- **AND** for each role override file under `personas/personal/roles/`, it
+  SHALL assert that a base role of the same name exists in the parent repo's
+  `roles/` directory (the parent `roles/` path is resolved relative to the
+  submodule mount via `../..`)
+
+### Requirement: CI simplification
+
+The `.github/workflows/ci.yml` workflow SHALL NOT contain any step that
+populates, copies, or rsyncs content into `personas/<name>/`.
+
+#### Scenario: CI omits the populate-personas step
+
+- **WHEN** the CI workflow YAML is inspected
+- **THEN** there SHALL NOT be any `run:` or `uses:` step whose effect is to
+  write files into `personas/personal/` or `personas/work/`
+- **AND** the `pytest` step SHALL succeed using only `tests/fixtures/personas/`
+  as its persona data source
+
+### Requirement: Documentation of the privacy boundary rule
+
+The repository SHALL document the public-vs-private test rule in both
+`CLAUDE.md` and `docs/gotchas.md`.
+
+#### Scenario: CLAUDE.md records the convention
+
+- **WHEN** `CLAUDE.md` is read
+- **THEN** the "Conventions" section SHALL contain a bullet stating that
+  public tests use fixtures only and that persona-specific tests live in the
+  persona's private submodule and are self-contained
+
+#### Scenario: docs/gotchas.md records the failure mode
+
+- **WHEN** `docs/gotchas.md` is read
+- **THEN** a new gotcha entry SHALL describe the private-content leakage
+  failure mode (symptom: CI passes locally but private strings appear in
+  public test assertions; root cause: `personas_dir` was pointed at the real
+  submodule; fix: repoint to fixtures + rely on the conftest guard;
+  prevention: let the collection guard catch new violations)

--- a/openspec/changes/test-privacy-boundary/tasks.md
+++ b/openspec/changes/test-privacy-boundary/tasks.md
@@ -114,13 +114,18 @@ scrub establishes a clean baseline; the guard then locks it in.
   **Dependencies**: 2.4, 2.5, 2.6, 2.7, 2.8
 
 - [ ] 2.10 Create `tests/_privacy_guard_config.py` defining
-  `FORBIDDEN_PATH_NAMES = ("personal", "work")` and
-  `ALLOWED_READ_PREFIXES = ("tests/fixtures/", "personas/_template/")`
-  plus the four-file exclusion list per D9.
+  `FORBIDDEN_PATH_NAMES = ("personal", "work")`,
+  `ALLOWED_READ_PREFIXES = ("tests/fixtures/", "personas/_template/")`,
+  and the **six-file** exclusion list per D9 (updated from four after
+  Round 2 B-N4): `_privacy_guard_config.py`, `_privacy_guard_plugin.py`,
+  `test_ci_workflow_hygiene.py`, `test_workspace_hygiene.py`, plus the
+  `tests/fixtures/` directory and `tests/_helpers/` directory (added per
+  D8's note that Python helpers relocate there).
   **Spec scenarios**: test-privacy-boundary/two-layer-collection-time-and-runtime-boundary-guard
   (guard-scope-excludes-its-own-implementation-files)
   **Contracts**: n/a
-  **Design decisions**: D2 (single source of truth), D9 (scope)
+  **Design decisions**: D2 (single source of truth), D9 (scope including
+  hygiene-test exclusions)
   **Dependencies**: 2.9
 
 - [ ] 2.11 Write `tests/test_privacy_guard.py` exercising both Layer 1 and
@@ -129,13 +134,26 @@ scrub establishes a clean baseline; the guard then locks it in.
   capture_output=True)`) rather than the `pytester` fixture — sidesteps
   the `pytest_plugins=["pytester"]` registration requirement (Round 1
   finding I6) and makes the tests independent of pytest plugin discovery.
-  Cover at minimum: Layer 1 substring rejection, Layer 1 allow-list, Layer
-  1 self-exclusion of `_privacy_guard_config.py`, Layer 2 runtime
-  rejection of `Path.read_text` on a forbidden path, Layer 2 allow-list,
-  Layer 2 rejection of `Path("personas") / "personal" / "x.yaml"`
-  constructed-path read.
+  Cover at minimum (expanded per Round 2 B-N1/B-N2/B-N8):
+  - Layer 1 substring rejection.
+  - Layer 1 allow-list.
+  - Layer 1 self-exclusion of `_privacy_guard_config.py` and
+    `_privacy_guard_plugin.py`, `test_ci_workflow_hygiene.py`,
+    `test_workspace_hygiene.py`.
+  - Layer 2 runtime rejection of `Path.read_text` on a forbidden path.
+  - Layer 2 runtime rejection of `os.open` on a forbidden path.
+  - Layer 2 runtime rejection of `io.FileIO` (transitively, via os.open).
+  - Layer 2 runtime rejection of `subprocess.run(['cat', forbidden_path])`
+    — both literal and split-argv cases.
+  - Layer 2 allow-list (reads under `tests/fixtures/` proceed).
+  - Layer 2 rejection of `Path("personas") / "personal" / "x.yaml"`
+    constructed-path read.
+  - Layer 2 self-probe fires when plugin fails to install (simulate by
+    monkey-patching the plugin's install function to no-op, assert
+    session fails).
   **Spec scenarios**: test-privacy-boundary/two-layer-collection-time-and-runtime-boundary-guard
-  (all six scenarios)
+  (all scenarios including layer-2-rejects-a-forbidden-subprocess-argv
+  and layer-2-self-probes-after-installation)
   **Contracts**: n/a
   **Design decisions**: D1, D9
   **Dependencies**: 2.10
@@ -153,23 +171,46 @@ scrub establishes a clean baseline; the guard then locks it in.
   **Dependencies**: 2.11
 
 - [ ] 2.13 Implement Layer 2 in `tests/_privacy_guard_plugin.py`. Patches
-  `pathlib.Path.open`, `pathlib.Path.read_text`,
-  `pathlib.Path.read_bytes`, and `builtins.open` for the duration of
-  pytest collection + run. Resolves each requested path, raises
-  `_PrivacyBoundaryViolation` (subclass of `pytest.UsageError`) if the
-  path resolves under `personas/<name>/` for `<name>` in
-  `FORBIDDEN_PATH_NAMES` and is not under any prefix in
-  `ALLOWED_READ_PREFIXES`. Wired in via `pytest_plugins =
-  ["_privacy_guard_plugin"]` at the top of `tests/conftest.py`.
+  **six** I/O entry points for the duration of pytest collection + run
+  (expanded per Round 2 B-N1/B-N2):
+  - `pathlib.Path.open`
+  - `pathlib.Path.read_text`
+  - `pathlib.Path.read_bytes`
+  - `builtins.open`
+  - `os.open` (canonical syscall choke point covering `io.FileIO`,
+    `codecs.open`, `io.open`)
+  - `subprocess.Popen.__init__` (scans argv elements for forbidden path
+    substrings, closing the `subprocess.run(['cat', 'personas/...'])`
+    bypass class)
+  Resolves each requested path, raises `_PrivacyBoundaryViolation`
+  (subclass of `pytest.UsageError`) if the path resolves under
+  `personas/<name>/` for `<name>` in `FORBIDDEN_PATH_NAMES` and is not
+  under any prefix in `ALLOWED_READ_PREFIXES`. For `subprocess.Popen`,
+  raises if any argv element contains `personas/<name>/` substring.
+  Wired in via `pytest_plugins = ["_privacy_guard_plugin"]` at the top
+  of `tests/conftest.py`.
+  **Plugin self-probe (B-N8)**: at `pytest_configure` time, after
+  installing patches, the plugin SHALL open a canary forbidden path
+  (under `personas/personal/`, non-allow-listed) and assert
+  `_PrivacyBoundaryViolation` is raised. If the probe does NOT raise,
+  the plugin fails the session via
+  `pytest.UsageError("Layer 2 privacy guard failed to install")`.
+  Prevents silent disable when future CPython changes break method-level
+  monkey-patching.
   **Spec scenarios**: test-privacy-boundary/two-layer-collection-time-and-runtime-boundary-guard
-  (Layer 2 scenarios)
+  (Layer 2 scenarios including layer-2-rejects-a-forbidden-subprocess-argv
+  and layer-2-self-probes-after-installation)
   **Contracts**: n/a
   **Design decisions**: D1
   **Dependencies**: 2.11
 
 - [ ] 2.14 Verification: run `uv run pytest tests/` — both guard tests
-  pass; full suite stays green. Confirms the guard does not produce false
-  positives on legitimate fixture-based tests.
+  pass; full suite stays green. Confirms the guard does not produce
+  false positives on legitimate fixture-based tests. Note that the two
+  hygiene tests (4.4, 4.5) are authored in `wp-ci-cleanup` (after the
+  populate-step removal in 4.1) rather than here, so this verification
+  does not attempt to run them — they are exercised in 5.2a after
+  wp-ci-cleanup lands.
   **Spec scenarios**: test-privacy-boundary/public-test-fixture-root
   (public-test-suite-passes-without-submodule-content)
   **Contracts**: n/a
@@ -229,15 +270,19 @@ scrub establishes a clean baseline; the guard then locks it in.
   **Dependencies**: none
 
 - [ ] 3.5 Write `personas/personal/tests/test_no_assistant_import.py` with
-  TWO checks (Round 1 finding A1):
+  TWO checks (Round 1 finding A1, refined per Round 2 B-N5):
   (a) **Static**: grep every `*.py` under `personas/personal/tests/` and
       fail if any contains `import assistant`, `from assistant`,
       `from src.assistant`, `__import__("assistant")`, or
       `importlib.import_module("assistant")` outside this very file.
   (b) **Runtime positive assertion**:
-      `with pytest.raises(ImportError): importlib.import_module("assistant")`.
-      This proves the venv truly does not have `assistant` installed; the
-      static check alone is bypassable via dynamic import idioms.
+      `with pytest.raises(ImportError): importlib.import_module("assistant.core.persona")`.
+      The **qualified path** (`.core.persona`) is distinctive to this
+      project and will NOT collide with the unrelated PyPI package also
+      named `assistant` (Round 2 B-N5). A bare
+      `importlib.import_module("assistant")` would spuriously succeed in
+      a venv where the PyPI squatter is installed and produce a misleading
+      failure unrelated to the privacy contract.
   **Spec scenarios**: test-privacy-boundary/self-contained-persona-submodule-test-suite
   (submodule-tests-assert-assistant-import-fails-at-runtime)
   **Contracts**: n/a
@@ -245,16 +290,23 @@ scrub establishes a clean baseline; the guard then locks it in.
   **Dependencies**: 3.3
 
 - [ ] 3.6 Verification — fresh-venv standalone proof. Replaces the
-  `PYTHONPATH=/dev/null` approach (Round 1 finding A1, also acknowledged
-  by F1 with regard to root-pytest testpaths). Create a script
-  `scripts/verify-submodule-standalone.sh` that:
+  `PYTHONPATH=/dev/null` approach (Round 1 finding A1, refined per
+  Round 2 B-N7). Create a script `scripts/verify-submodule-standalone.sh`
+  that:
   (1) creates a fresh venv: `python -m venv /tmp/spb-venv`,
-  (2) installs only pytest + pyyaml: `/tmp/spb-venv/bin/pip install pytest pyyaml`,
-  (3) runs `/tmp/spb-venv/bin/pytest personas/personal/tests/`,
-  (4) asserts exit status 0,
-  (5) cleans up via `trap`.
+  (2) installs only pytest + pyyaml with pinned minimums:
+      `/tmp/spb-venv/bin/pip install 'pytest>=8' 'pyyaml>=6'`,
+  (3) `cd personas/personal` **before** invoking pytest (Round 2 B-N7 —
+      this makes pytest's rootdir the submodule's pyproject, not the
+      parent's, so the parent's `pytest_plugins` do NOT load against
+      submodule tests),
+  (4) runs `/tmp/spb-venv/bin/pytest tests/ --rootdir=. --override-ini='addopts='`,
+  (5) asserts exit status 0,
+  (6) cleans up via `trap` on both EXIT and any interrupt signal.
   Also independently verify `cd personas/personal && uv run pytest tests/`
-  succeeds when the submodule is consumed in-place from a parent checkout.
+  succeeds when the submodule is consumed in-place from a parent checkout
+  (this exercises the `[tool.uv].package = false` boundary from D4 +
+  the workspace-forward-compat guard from task 4.5).
   **Spec scenarios**: test-privacy-boundary/self-contained-persona-submodule-test-suite
   (standalone-proof-verification-uses-a-fresh-venv,
   submodule-pyproject-declares-an-isolated-workspace)
@@ -298,19 +350,69 @@ scrub establishes a clean baseline; the guard then locks it in.
   **Dependencies**: none
 
 - [ ] 4.4 Write `tests/test_ci_workflow_hygiene.py` — scans every
-  `.github/workflows/*.yml` for references to `personas/personal/` or
-  `personas/work/`. Fails if any reference is not paired with an explicit
-  copy-from-`tests/fixtures/` step (or if any `.yml` mentions the
-  forbidden path at all, since after D6 there should be zero such
-  references). Catches the regression class flagged by Round 1 finding A7.
+  `.github/workflows/*.yml` (and `*.yaml`, and `.github/actions/**/action.yml`)
+  for references to forbidden persona paths. **Constructs its forbidden
+  needle dynamically** from
+  `tests._privacy_guard_config.FORBIDDEN_PATH_NAMES`
+  (per Round 2 B-N4):
+  ```python
+  from tests._privacy_guard_config import FORBIDDEN_PATH_NAMES
+  needles = tuple(f"personas/{name}/" for name in FORBIDDEN_PATH_NAMES)
+  ```
+  so the file's own source never contains the literal forbidden
+  substring and Layer 1 doesn't self-trip. (Belt-and-suspenders: this
+  file is ALSO in the Layer 1 exclusion list per 2.10.) Fails if any
+  matched reference is not paired with an explicit
+  copy-from-`tests/fixtures/` step — or, since D6 removes the populate
+  step entirely, if any `.yml`/`.yaml`/`action.yml` mentions the
+  forbidden path at all.
   **Spec scenarios**: test-privacy-boundary/ci-simplification-and-forward-compatible-hygiene-check
   (workflow-hygiene-test-rejects-future-leakage-paths)
   **Contracts**: n/a
-  **Design decisions**: R4
-  **Dependencies**: 2.10 (uses the same FORBIDDEN_PATH_NAMES constants),
-  4.1
+  **Design decisions**: R4, D9 (dynamic needle + exclusion)
+  **Dependencies**: 2.10 (uses the FORBIDDEN_PATH_NAMES constants + is
+  in the exclusion list), 4.1
+
+- [ ] 4.5 Write `tests/test_workspace_hygiene.py` — parses the parent
+  `pyproject.toml` (via `tomllib`) and asserts that either (a) no
+  `[tool.uv.workspace]` section exists, or (b) if it does, `members` does
+  NOT contain any glob matching `personas/personal/` or `personas/work/`
+  (e.g. `personas/*`, `personas/**`). Guards against a future
+  dev-ergonomics change drawing the submodule into the parent venv and
+  silently defeating self-containment (Round 2 B-N6). Like 4.4, this
+  file is in the Layer 1 exclusion list (per 2.10) and uses dynamic
+  needle construction.
+  **Spec scenarios**: test-privacy-boundary/self-contained-persona-submodule-test-suite
+  (parent-pyproject-does-not-include-submodule-in-a-uv-workspace)
+  **Contracts**: n/a
+  **Design decisions**: D4 (forward-compat guard)
+  **Dependencies**: 2.10
 
 ## Phase 5 — Integration
+
+- [ ] 5.0 Create `scripts/push-with-submodule.sh` (authoring task added per
+  Round 2 finding B-N3 — previously referenced by 5.3a/5.3b but not
+  authored by any task). The script SHALL support two invocation modes:
+  - `--submodule-only`: `cd personas/personal`, verify we're at
+    `origin/main` or a documented branch, `git push` to the private
+    remote, print the pushed SHA to stdout as the last line.
+  - `--parent-only`: verify the parent branch is rebased onto
+    `origin/main`, `git add personas/personal` (gitlink update), commit
+    with a message including the submodule SHA, push parent branch.
+    If push fails after submodule push had succeeded, log the
+    dangling-SHA diagnostic (submodule SHA + parent HEAD at failure +
+    suggested recovery command: `git -C personas/personal push -d
+    origin <branch-with-dangling-sha>` or open an operator ticket) and
+    exit with a distinctive non-zero code (e.g. 47) that the 5.3-alt
+    dispatcher recognizes.
+  The script SHALL be idempotent within a mode (re-invoking
+  `--parent-only` after a successful push is a no-op) and SHALL NOT
+  require `--submodule-only` and `--parent-only` to be invoked by the
+  same process. Exit-code contract documented inline.
+  **Spec scenarios**: n/a (ops tooling)
+  **Contracts**: n/a
+  **Design decisions**: D7 (atomic push wrapper)
+  **Dependencies**: none
 
 - [ ] 5.1 Run `openspec validate test-privacy-boundary --strict` and fix
   any validation errors.
@@ -359,22 +461,40 @@ scrub establishes a clean baseline; the guard then locks it in.
   **Design decisions**: D7
   **Dependencies**: 5.3a
 
-- [ ] 5.3-alt Fallback for missing private-repo write access (Round 1
-  finding I9): if 5.3a's push fails due to credential absence, the
-  dispatcher SHALL quarantine `wp-submodule-tests` with a clearly-flagged
-  status (`requires-private-repo-write`) and emit a handoff message
-  containing the exact `git -C personas/personal push <branch>` command
-  and the parent SHA-bump commit needed to follow up. The change is not
-  marked failed; it waits for an operator with credentials.
+- [ ] 5.3-alt Fallback for missing private-repo write access
+  (Round 1 finding I9, trigger semantics clarified per Round 2 A-N2).
+  This task is **dispatch-time-driven**, not runtime-driven: the
+  dispatcher inspects `wp-submodule-tests.constraints.requires_private_repo_write`
+  and, if credentials are not available in the execution environment,
+  the dispatcher SHALL quarantine `wp-submodule-tests` with a
+  clearly-flagged status (`requires-private-repo-write`) and emit a
+  handoff message containing (a) the exact
+  `git -C personas/personal push <branch>` command, (b) the parent
+  SHA-bump commit message template, and (c) the exit code 47 diagnostic
+  from `scripts/push-with-submodule.sh` if 5.3a had been attempted.
+  Additionally, if 5.3a is actually attempted (credentials looked
+  available but push failed at runtime due to auth error or drift), the
+  same quarantine path fires on receiving exit code 47. The change is
+  NOT marked failed in either case; it waits for an operator with
+  credentials. This dual trigger (dispatch-time + runtime exit-code 47)
+  is the explicit contract.
   **Spec scenarios**: n/a (ops)
   **Contracts**: n/a
-  **Design decisions**: R3
-  **Dependencies**: 5.3a (only fires on its failure)
+  **Design decisions**: R3 (private-repo write access)
+  **Dependencies**: none at dispatch time; 5.3a at runtime
 
-- [ ] 5.4 Push parent branch `openspec/test-privacy-boundary` to origin
-  and open PR. (Subsumed by 5.3b's `--parent-only` path; this task only
-  applies if 5.3b is split or skipped.)
+- [ ] 5.4 Open the pull request for the parent branch
+  `openspec/test-privacy-boundary` via `gh pr create`. Title:
+  `plan(test-privacy-boundary): privacy-boundary between public tests
+  and persona submodules`. Body: proposal summary + convergence trail
+  (rounds, findings resolved, remaining known gaps per design R2) +
+  the two-commit topology notice (parent PR references a specific
+  submodule SHA; reviewers must check out the submodule at that SHA to
+  review the submodule-side content, or be pointed at the private-repo
+  PR). This task is **not subsumed by 5.3b** (clarified per Round 2
+  A-N1); 5.3b pushes the parent branch, 5.4 opens the PR. They are
+  distinct steps.
   **Spec scenarios**: n/a (ops)
   **Contracts**: n/a
-  **Design decisions**: none
+  **Design decisions**: D7 (two-commit topology visibility)
   **Dependencies**: 5.3b

--- a/openspec/changes/test-privacy-boundary/tasks.md
+++ b/openspec/changes/test-privacy-boundary/tasks.md
@@ -1,0 +1,228 @@
+# Tasks: test-privacy-boundary
+
+Task ordering follows TDD: test tasks precede the implementation tasks they
+verify. Each implementation task declares its test-task dependency.
+
+## Phase 1 — Contracts scaffold
+
+- [ ] 1.1 Create `contracts/README.md` documenting that no API, DB, or event
+  contract sub-types apply to this change (the change only touches test
+  infrastructure and CI, no external interfaces).
+  **Spec scenarios**: none (documentation-only)
+  **Contracts**: n/a
+  **Design decisions**: n/a
+  **Dependencies**: none
+
+## Phase 2 — Public test boundary (TDD)
+
+- [ ] 2.1 Write `tests/test_privacy_guard.py` — exercises the collection-time
+  guard against three synthetic in-memory "bad" test files (path reference,
+  private-content string, `_template` path that should be allowed). Uses
+  `pytest`'s `pytester` fixture.
+  **Spec scenarios**: test-privacy-boundary/collection-time-boundary-guard
+  (guard-rejects-forbidden-path-reference, guard-rejects-private-content-string,
+  guard-allows-template-and-fixture-references, guard-covers-both-personal-and-work)
+  **Contracts**: n/a
+  **Design decisions**: D1 (collection-time, not runtime), D2 (deny-list as
+  module constants)
+  **Dependencies**: 1.1
+
+- [ ] 2.2 Implement `pytest_collection_modifyitems` hook in
+  `tests/conftest.py`. Define `FORBIDDEN_PATH_SUBSTRINGS`,
+  `FORBIDDEN_CONTENT_STRINGS`, `ALLOWED_PATH_SUBSTRINGS` module constants per
+  D2. Read each collected `item.fspath`'s source text once per file
+  (memoize), fail with `pytest.UsageError` on first violation.
+  **Spec scenarios**: test-privacy-boundary/collection-time-boundary-guard
+  (all four scenarios)
+  **Contracts**: n/a
+  **Design decisions**: D1, D2
+  **Dependencies**: 2.1
+
+- [ ] 2.3 Write test asserting that `personas_dir` fixture resolves to
+  `tests/fixtures/personas/`, not `REPO_ROOT/personas/`.
+  **Spec scenarios**: test-privacy-boundary/public-test-fixture-root
+  (public-personas_dir-fixture-resolves-to-fixtures-root)
+  **Contracts**: n/a
+  **Design decisions**: none
+  **Dependencies**: 1.1
+
+- [ ] 2.4 Repoint `personas_dir` fixture in `tests/conftest.py` from
+  `REPO_ROOT / "personas"` to `REPO_ROOT / "tests" / "fixtures" / "personas"`.
+  **Spec scenarios**: test-privacy-boundary/public-test-fixture-root
+  (public-personas_dir-fixture-resolves-to-fixtures-root,
+  public-test-suite-passes-without-submodule-content)
+  **Contracts**: n/a
+  **Design decisions**: none
+  **Dependencies**: 2.3
+
+- [ ] 2.5 Scrub private-content assertions from `tests/test_composition.py`
+  (specifically `test_composition_against_real_configs` at lines 112-122).
+  Rewrite to assert only against fixture-derived content; move any assertion
+  that depends on real-persona prompt strings to Phase 3 (submodule suite) or
+  delete if redundant with the fixture-based variant.
+  **Spec scenarios**: test-privacy-boundary/public-test-fixture-root
+  (public-test-suite-passes-without-submodule-content)
+  **Contracts**: n/a
+  **Design decisions**: none
+  **Dependencies**: 2.2, 2.4
+
+- [ ] 2.6 Scrub private-content assertions from `tests/test_role_registry.py`
+  — in particular line 67 (`"Personal Context Additions"`). Rewrite against
+  fixture values from `tests/fixtures/personas/personal/roles/researcher.yaml`;
+  move any real-content check to the submodule suite.
+  **Spec scenarios**: test-privacy-boundary/public-test-fixture-root
+  (public-test-suite-passes-without-submodule-content);
+  test-privacy-boundary/collection-time-boundary-guard
+  (guard-rejects-private-content-string)
+  **Contracts**: n/a
+  **Design decisions**: none
+  **Dependencies**: 2.2, 2.4
+
+- [ ] 2.7 Audit `tests/test_persona_registry.py` line 83
+  (`"Personal Persona Context" in cfg.prompt_augmentation`) and rewrite
+  against fixture content.
+  **Spec scenarios**: test-privacy-boundary/public-test-fixture-root
+  **Contracts**: n/a
+  **Design decisions**: none
+  **Dependencies**: 2.2, 2.4
+
+- [ ] 2.8 Audit `tests/test_delegation.py` and `tests/test_cli.py` for any
+  residual assertions on private-content strings; rewrite against fixture
+  values. These files primarily reference the word `"personal"` as a persona
+  name (which is not private), so most uses are fine.
+  **Spec scenarios**: test-privacy-boundary/public-test-fixture-root
+  **Contracts**: n/a
+  **Design decisions**: none
+  **Dependencies**: 2.2, 2.4
+
+- [ ] 2.9 Verification: run `uv run pytest tests/` with the real
+  `personas/personal/` submodule temporarily moved aside
+  (`mv personas/personal /tmp/pers-backup && git status`). Must exit 0.
+  Restore after.
+  **Spec scenarios**: test-privacy-boundary/public-test-fixture-root
+  (public-test-suite-passes-without-submodule-content)
+  **Contracts**: n/a
+  **Design decisions**: none
+  **Dependencies**: 2.5, 2.6, 2.7, 2.8
+
+## Phase 3 — Submodule self-contained test suite
+
+- [ ] 3.1 Write `personas/personal/tests/test_persona_yaml.py` — asserts
+  `persona.yaml` contains required top-level keys (`name`, `display_name`,
+  `database`, `auth`, `harnesses`, `default_role`) and that all `*_env` values
+  follow the `PERSONAL_*` prefix convention. Uses `yaml.safe_load` only; no
+  imports from `assistant.*`.
+  **Spec scenarios**: test-privacy-boundary/self-contained-persona-submodule-test-suite
+  (submodule-tests-run-standalone, submodule-suite-validates-yaml-shape)
+  **Contracts**: n/a
+  **Design decisions**: D3 (direct YAML parse, no PersonaConfig),
+  D4 (pyproject deps = pytest + pyyaml)
+  **Dependencies**: 1.1
+
+- [ ] 3.2 Write `personas/personal/tests/test_role_overrides.py` — for each
+  `*.yaml` under `personas/personal/roles/`, assert a matching base role exists
+  at `<parent>/roles/<name>/role.yaml`. If the parent repo's `roles/` directory
+  is not resolvable (standalone mode), `pytest.skip` with a descriptive
+  message per D5.
+  **Spec scenarios**: test-privacy-boundary/self-contained-persona-submodule-test-suite
+  (submodule-suite-validates-yaml-shape)
+  **Contracts**: n/a
+  **Design decisions**: D3, D5 (parent roles resolved via `../../roles`)
+  **Dependencies**: 1.1
+
+- [ ] 3.3 Write `personas/personal/tests/conftest.py` — minimal fixtures that
+  expose `persona_root = Path(__file__).resolve().parents[1]` and optionally
+  `parent_roles_dir` (None if not present). Zero imports from `assistant.*`.
+  **Spec scenarios**: test-privacy-boundary/self-contained-persona-submodule-test-suite
+  (submodule-tests-run-standalone)
+  **Contracts**: n/a
+  **Design decisions**: D3, D5
+  **Dependencies**: 3.1, 3.2
+
+- [ ] 3.4 Write `personas/personal/pyproject.toml` — declare `pytest>=8` and
+  `pyyaml>=6` as dev dependencies. No `build-backend`; this is not an
+  installable package per D4.
+  **Spec scenarios**: test-privacy-boundary/self-contained-persona-submodule-test-suite
+  (submodule-tests-run-standalone)
+  **Contracts**: n/a
+  **Design decisions**: D4
+  **Dependencies**: none
+
+- [ ] 3.5 Write assertion (as a meta-test at
+  `personas/personal/tests/test_no_assistant_import.py`) that greps every
+  `*.py` under `personas/personal/tests/` and fails if any contains
+  `import assistant`, `from assistant`, or `from src.assistant`.
+  **Spec scenarios**: test-privacy-boundary/self-contained-persona-submodule-test-suite
+  (submodule-tests-run-standalone)
+  **Contracts**: n/a
+  **Design decisions**: D3
+  **Dependencies**: 3.3
+
+- [ ] 3.6 Verification: `cd personas/personal && uv run pytest tests/` exits
+  0. Also verify `PYTHONPATH=/dev/null uv run pytest personas/personal/tests/`
+  (proof of standalone) exits 0.
+  **Spec scenarios**: test-privacy-boundary/self-contained-persona-submodule-test-suite
+  (submodule-tests-run-standalone)
+  **Contracts**: n/a
+  **Design decisions**: D3
+  **Dependencies**: 3.1, 3.2, 3.3, 3.4, 3.5
+
+## Phase 4 — CI and documentation
+
+- [ ] 4.1 Remove the `populate personas/personal from test fixture` step from
+  `.github/workflows/ci.yml` (lines 41-44 per the CI investigation).
+  **Spec scenarios**: test-privacy-boundary/ci-simplification
+  (ci-omits-the-populate-personas-step)
+  **Contracts**: n/a
+  **Design decisions**: D6 (remove, not keep as safety net)
+  **Dependencies**: 2.4
+
+- [ ] 4.2 Add a new gotcha entry `G6: Private-persona content leakage via
+  public test assertions` to `docs/gotchas.md` following the existing
+  symptom/root-cause/fix/prevention format.
+  **Spec scenarios**: test-privacy-boundary/documentation-of-the-privacy-boundary-rule
+  (docs-gotchas-md-records-the-failure-mode)
+  **Contracts**: n/a
+  **Design decisions**: none
+  **Dependencies**: 2.2
+
+- [ ] 4.3 Update `CLAUDE.md` "Conventions" section with the bullet: "Public
+  tests use fixtures only (`tests/fixtures/personas/`); persona-specific
+  tests live in each persona's private submodule and must be self-contained
+  (no imports from `src/assistant/*`)."
+  **Spec scenarios**: test-privacy-boundary/documentation-of-the-privacy-boundary-rule
+  (claude-md-records-the-convention)
+  **Contracts**: n/a
+  **Design decisions**: none
+  **Dependencies**: none
+
+## Phase 5 — Integration
+
+- [ ] 5.1 Run `openspec validate test-privacy-boundary --strict` and fix any
+  validation errors.
+  **Spec scenarios**: n/a
+  **Contracts**: n/a
+  **Design decisions**: none
+  **Dependencies**: all of Phase 2, 3, 4
+
+- [ ] 5.2 Run full `uv run pytest` at the repo root — all tests green.
+  **Spec scenarios**: all
+  **Contracts**: n/a
+  **Design decisions**: none
+  **Dependencies**: 2.9, 3.6, 4.1, 4.2, 4.3
+
+- [ ] 5.3 Commit submodule content inside `personas/personal/`, push to its
+  private remote (e.g. `github.com/jankneumann/agentic-assistant-config-personal`),
+  then `git add personas/personal` in the parent to update the submodule SHA
+  pointer. Commit parent changes.
+  **Spec scenarios**: n/a (ops)
+  **Contracts**: n/a
+  **Design decisions**: D7 (submodule + parent as two commits)
+  **Dependencies**: 3.6, 5.2
+
+- [ ] 5.4 Push parent branch `openspec/test-privacy-boundary` to origin and
+  open PR.
+  **Spec scenarios**: n/a (ops)
+  **Contracts**: n/a
+  **Design decisions**: none
+  **Dependencies**: 5.3

--- a/openspec/changes/test-privacy-boundary/tasks.md
+++ b/openspec/changes/test-privacy-boundary/tasks.md
@@ -3,226 +3,378 @@
 Task ordering follows TDD: test tasks precede the implementation tasks they
 verify. Each implementation task declares its test-task dependency.
 
+**Phase 2 ordering note (Round 1 fix for I1)**: The two-layer guard
+implementation (`2.10`, `2.11`) is intentionally sequenced **after** the
+public-test scrub tasks (`2.4`–`2.8`). If the guard were enabled while the
+existing tests still contained literal forbidden substrings, every guard
+self-test invocation would fail collection on the unscrubbed tests. The
+scrub establishes a clean baseline; the guard then locks it in.
+
 ## Phase 1 — Contracts scaffold
 
-- [ ] 1.1 Create `contracts/README.md` documenting that no API, DB, or event
-  contract sub-types apply to this change (the change only touches test
-  infrastructure and CI, no external interfaces).
+- [ ] 1.1 Create `contracts/README.md` documenting that no API, DB, or
+  event contract sub-types apply to this change (the change only touches
+  test infrastructure and CI, no external interfaces).
   **Spec scenarios**: none (documentation-only)
   **Contracts**: n/a
   **Design decisions**: n/a
   **Dependencies**: none
 
-## Phase 2 — Public test boundary (TDD)
+## Phase 2 — Public test boundary (TDD; scrub-then-guard ordering)
 
-- [ ] 2.1 Write `tests/test_privacy_guard.py` — exercises the collection-time
-  guard against three synthetic in-memory "bad" test files (path reference,
-  private-content string, `_template` path that should be allowed). Uses
-  `pytest`'s `pytester` fixture.
-  **Spec scenarios**: test-privacy-boundary/collection-time-boundary-guard
-  (guard-rejects-forbidden-path-reference, guard-rejects-private-content-string,
-  guard-allows-template-and-fixture-references, guard-covers-both-personal-and-work)
+- [ ] 2.1 Add a `FIXTURE_PERSONA_SENTINEL` marker string to
+  `tests/fixtures/personas/personal/prompt.md` (and the corresponding role
+  yamls if they participate in composition) so the fixture-based
+  composition test (task 2.3) has a unique-to-fixture string to assert on.
+  Choose a string that is unmistakably fixture-only (e.g.
+  `"FIXTURE_PERSONA_SENTINEL_v1"`) and document it inline.
+  **Spec scenarios**: test-privacy-boundary/replacement-integration-coverage-for-compose_system_prompt
+  (fixture-based-composition-test-asserts-on-a-fixture-sentinel)
   **Contracts**: n/a
-  **Design decisions**: D1 (collection-time, not runtime), D2 (deny-list as
-  module constants)
+  **Design decisions**: D2 (we no longer track private-content strings; we
+  track fixture sentinels instead)
   **Dependencies**: 1.1
 
-- [ ] 2.2 Implement `pytest_collection_modifyitems` hook in
-  `tests/conftest.py`. Define `FORBIDDEN_PATH_SUBSTRINGS`,
-  `FORBIDDEN_CONTENT_STRINGS`, `ALLOWED_PATH_SUBSTRINGS` module constants per
-  D2. Read each collected `item.fspath`'s source text once per file
-  (memoize), fail with `pytest.UsageError` on first violation.
-  **Spec scenarios**: test-privacy-boundary/collection-time-boundary-guard
-  (all four scenarios)
-  **Contracts**: n/a
-  **Design decisions**: D1, D2
-  **Dependencies**: 2.1
-
-- [ ] 2.3 Write test asserting that `personas_dir` fixture resolves to
-  `tests/fixtures/personas/`, not `REPO_ROOT/personas/`.
+- [ ] 2.2 Repoint `personas_dir` fixture in `tests/conftest.py` from
+  `REPO_ROOT / "personas"` to `REPO_ROOT / "tests" / "fixtures" / "personas"`.
   **Spec scenarios**: test-privacy-boundary/public-test-fixture-root
   (public-personas_dir-fixture-resolves-to-fixtures-root)
   **Contracts**: n/a
   **Design decisions**: none
   **Dependencies**: 1.1
 
-- [ ] 2.4 Repoint `personas_dir` fixture in `tests/conftest.py` from
-  `REPO_ROOT / "personas"` to `REPO_ROOT / "tests" / "fixtures" / "personas"`.
+- [ ] 2.3 Write a fixture-based composition integration test in
+  `tests/test_composition.py` that loads the fixture `personal` persona +
+  `researcher` role, calls `compose_system_prompt`, and asserts that the
+  output contains `FIXTURE_PERSONA_SENTINEL_v1`. This replaces the lost
+  end-to-end coverage of `compose_system_prompt` against real persona data
+  (Round 1 finding F4).
+  **Spec scenarios**: test-privacy-boundary/replacement-integration-coverage-for-compose_system_prompt
+  (fixture-based-composition-test-asserts-on-a-fixture-sentinel)
+  **Contracts**: n/a
+  **Design decisions**: none
+  **Dependencies**: 2.1, 2.2
+
+- [ ] 2.4 Scrub `test_composition_against_real_configs` (existing test in
+  `tests/test_composition.py:112-122`) — delete it; replaced by 2.3.
   **Spec scenarios**: test-privacy-boundary/public-test-fixture-root
-  (public-personas_dir-fixture-resolves-to-fixtures-root,
-  public-test-suite-passes-without-submodule-content)
+  (public-test-suite-passes-without-submodule-content)
   **Contracts**: n/a
   **Design decisions**: none
   **Dependencies**: 2.3
 
-- [ ] 2.5 Scrub private-content assertions from `tests/test_composition.py`
-  (specifically `test_composition_against_real_configs` at lines 112-122).
-  Rewrite to assert only against fixture-derived content; move any assertion
-  that depends on real-persona prompt strings to Phase 3 (submodule suite) or
-  delete if redundant with the fixture-based variant.
+- [ ] 2.5 Scrub private-content assertions from `tests/test_role_registry.py`
+  — in particular line 67 (`"Personal Context Additions"`). Rewrite all
+  assertions against fixture values from
+  `tests/fixtures/personas/personal/roles/researcher.yaml`. Where the real
+  persona's role override carried unique content not present in the
+  fixture, either (a) add the equivalent fixture-only sentinel and assert
+  on it, or (b) move the assertion to the submodule suite (Phase 3).
   **Spec scenarios**: test-privacy-boundary/public-test-fixture-root
   (public-test-suite-passes-without-submodule-content)
   **Contracts**: n/a
   **Design decisions**: none
-  **Dependencies**: 2.2, 2.4
+  **Dependencies**: 2.2
 
-- [ ] 2.6 Scrub private-content assertions from `tests/test_role_registry.py`
-  — in particular line 67 (`"Personal Context Additions"`). Rewrite against
-  fixture values from `tests/fixtures/personas/personal/roles/researcher.yaml`;
-  move any real-content check to the submodule suite.
-  **Spec scenarios**: test-privacy-boundary/public-test-fixture-root
-  (public-test-suite-passes-without-submodule-content);
-  test-privacy-boundary/collection-time-boundary-guard
-  (guard-rejects-private-content-string)
-  **Contracts**: n/a
-  **Design decisions**: none
-  **Dependencies**: 2.2, 2.4
-
-- [ ] 2.7 Audit `tests/test_persona_registry.py` line 83
+- [ ] 2.6 Audit `tests/test_persona_registry.py` line 83
   (`"Personal Persona Context" in cfg.prompt_augmentation`) and rewrite
-  against fixture content.
+  against the `FIXTURE_PERSONA_SENTINEL_v1` (or another fixture-defined
+  marker added in 2.1).
   **Spec scenarios**: test-privacy-boundary/public-test-fixture-root
   **Contracts**: n/a
   **Design decisions**: none
-  **Dependencies**: 2.2, 2.4
+  **Dependencies**: 2.1, 2.2
 
-- [ ] 2.8 Audit `tests/test_delegation.py` and `tests/test_cli.py` for any
-  residual assertions on private-content strings; rewrite against fixture
-  values. These files primarily reference the word `"personal"` as a persona
-  name (which is not private), so most uses are fine.
+- [ ] 2.7 Audit `tests/test_delegation.py` for any residual assertions on
+  private-content strings; rewrite against fixture values.
   **Spec scenarios**: test-privacy-boundary/public-test-fixture-root
   **Contracts**: n/a
   **Design decisions**: none
-  **Dependencies**: 2.2, 2.4
+  **Dependencies**: 2.2
 
-- [ ] 2.9 Verification: run `uv run pytest tests/` with the real
-  `personas/personal/` submodule temporarily moved aside
-  (`mv personas/personal /tmp/pers-backup && git status`). Must exit 0.
-  Restore after.
+- [ ] 2.8 Audit `tests/test_cli.py` for any residual private-string
+  assertions; rewrite against fixture values. Most uses of the word
+  `"personal"` here are persona names (not private), so most uses are
+  fine — verify and document each.
+  **Spec scenarios**: test-privacy-boundary/public-test-fixture-root
+  **Contracts**: n/a
+  **Design decisions**: none
+  **Dependencies**: 2.2
+
+- [ ] 2.9 Verification: invoke `bash scripts/verify-public-tests-standalone.sh`
+  (created in this task). The script wraps `git submodule deinit -f
+  personas/personal`, runs `uv run pytest tests/`, then restores via
+  `git submodule update --init personas/personal`. The wrapper uses
+  `trap` to guarantee restoration even on pytest failure or interrupt.
+  Replaces the unsafe `mv` approach (Round 1 finding I5).
   **Spec scenarios**: test-privacy-boundary/public-test-fixture-root
   (public-test-suite-passes-without-submodule-content)
   **Contracts**: n/a
   **Design decisions**: none
-  **Dependencies**: 2.5, 2.6, 2.7, 2.8
+  **Dependencies**: 2.4, 2.5, 2.6, 2.7, 2.8
+
+- [ ] 2.10 Create `tests/_privacy_guard_config.py` defining
+  `FORBIDDEN_PATH_NAMES = ("personal", "work")` and
+  `ALLOWED_READ_PREFIXES = ("tests/fixtures/", "personas/_template/")`
+  plus the four-file exclusion list per D9.
+  **Spec scenarios**: test-privacy-boundary/two-layer-collection-time-and-runtime-boundary-guard
+  (guard-scope-excludes-its-own-implementation-files)
+  **Contracts**: n/a
+  **Design decisions**: D2 (single source of truth), D9 (scope)
+  **Dependencies**: 2.9
+
+- [ ] 2.11 Write `tests/test_privacy_guard.py` exercising both Layer 1 and
+  Layer 2 against synthetic test trees. **Use subprocess-based testing**
+  (`subprocess.run([sys.executable, "-m", "pytest", str(tmp_path)],
+  capture_output=True)`) rather than the `pytester` fixture — sidesteps
+  the `pytest_plugins=["pytester"]` registration requirement (Round 1
+  finding I6) and makes the tests independent of pytest plugin discovery.
+  Cover at minimum: Layer 1 substring rejection, Layer 1 allow-list, Layer
+  1 self-exclusion of `_privacy_guard_config.py`, Layer 2 runtime
+  rejection of `Path.read_text` on a forbidden path, Layer 2 allow-list,
+  Layer 2 rejection of `Path("personas") / "personal" / "x.yaml"`
+  constructed-path read.
+  **Spec scenarios**: test-privacy-boundary/two-layer-collection-time-and-runtime-boundary-guard
+  (all six scenarios)
+  **Contracts**: n/a
+  **Design decisions**: D1, D9
+  **Dependencies**: 2.10
+
+- [ ] 2.12 Implement Layer 1 (`pytest_collection_modifyitems` hook) in
+  `tests/conftest.py`. Read each scanned file's source text once
+  (memoize), match against `FORBIDDEN_PATH_NAMES` substrings, fail with
+  `pytest.UsageError` on first violation. Failure message names the file
+  and matched deny-list entry but **does not** echo file content (per
+  spec scenario "Guard failure messages do not echo private payloads").
+  **Spec scenarios**: test-privacy-boundary/two-layer-collection-time-and-runtime-boundary-guard
+  (Layer 1 scenarios + failure-messages-do-not-echo-private-payloads)
+  **Contracts**: n/a
+  **Design decisions**: D1, D9
+  **Dependencies**: 2.11
+
+- [ ] 2.13 Implement Layer 2 in `tests/_privacy_guard_plugin.py`. Patches
+  `pathlib.Path.open`, `pathlib.Path.read_text`,
+  `pathlib.Path.read_bytes`, and `builtins.open` for the duration of
+  pytest collection + run. Resolves each requested path, raises
+  `_PrivacyBoundaryViolation` (subclass of `pytest.UsageError`) if the
+  path resolves under `personas/<name>/` for `<name>` in
+  `FORBIDDEN_PATH_NAMES` and is not under any prefix in
+  `ALLOWED_READ_PREFIXES`. Wired in via `pytest_plugins =
+  ["_privacy_guard_plugin"]` at the top of `tests/conftest.py`.
+  **Spec scenarios**: test-privacy-boundary/two-layer-collection-time-and-runtime-boundary-guard
+  (Layer 2 scenarios)
+  **Contracts**: n/a
+  **Design decisions**: D1
+  **Dependencies**: 2.11
+
+- [ ] 2.14 Verification: run `uv run pytest tests/` — both guard tests
+  pass; full suite stays green. Confirms the guard does not produce false
+  positives on legitimate fixture-based tests.
+  **Spec scenarios**: test-privacy-boundary/public-test-fixture-root
+  (public-test-suite-passes-without-submodule-content)
+  **Contracts**: n/a
+  **Design decisions**: D1, D9
+  **Dependencies**: 2.12, 2.13
 
 ## Phase 3 — Submodule self-contained test suite
 
 - [ ] 3.1 Write `personas/personal/tests/test_persona_yaml.py` — asserts
   `persona.yaml` contains required top-level keys (`name`, `display_name`,
-  `database`, `auth`, `harnesses`, `default_role`) and that all `*_env` values
-  follow the `PERSONAL_*` prefix convention. Uses `yaml.safe_load` only; no
-  imports from `assistant.*`.
+  `database`, `auth`, `harnesses`, `default_role`). Explicitly enumerates
+  the three env-reference checks (Round 1 finding I7):
+  (a) `database.url_env` starts with `PERSONAL_`,
+  (b) `graphiti.url_env` starts with `PERSONAL_` if the `graphiti` block
+  exists (else assert intentional absence),
+  (c) every value of `auth.config.*_env` starts with `PERSONAL_`.
+  Uses `yaml.safe_load` only; no imports from `assistant.*`.
   **Spec scenarios**: test-privacy-boundary/self-contained-persona-submodule-test-suite
-  (submodule-tests-run-standalone, submodule-suite-validates-yaml-shape)
+  (submodule-suite-validates-yaml-shape)
   **Contracts**: n/a
   **Design decisions**: D3 (direct YAML parse, no PersonaConfig),
   D4 (pyproject deps = pytest + pyyaml)
   **Dependencies**: 1.1
 
-- [ ] 3.2 Write `personas/personal/tests/test_role_overrides.py` — for each
-  `*.yaml` under `personas/personal/roles/`, assert a matching base role exists
-  at `<parent>/roles/<name>/role.yaml`. If the parent repo's `roles/` directory
-  is not resolvable (standalone mode), `pytest.skip` with a descriptive
-  message per D5.
+- [ ] 3.2 Write `personas/personal/tests/test_role_overrides.py` — for
+  each `*.yaml` under `personas/personal/roles/`, assert a matching base
+  role exists at `<parent>/roles/<name>/role.yaml`. If the parent repo's
+  `roles/` directory is not resolvable, the test SHALL `pytest.fail`
+  unless `ALLOW_STANDALONE_SUBMODULE_SKIP=1` is set, in which case it
+  SHALL `pytest.skip` with a loud message naming the env var (Round 1
+  finding A6).
   **Spec scenarios**: test-privacy-boundary/self-contained-persona-submodule-test-suite
-  (submodule-suite-validates-yaml-shape)
+  (submodule-suite-validates-yaml-shape, standalone-mode-requires-explicit-opt-in)
   **Contracts**: n/a
-  **Design decisions**: D3, D5 (parent roles resolved via `../../roles`)
+  **Design decisions**: D3, D5
   **Dependencies**: 1.1
 
-- [ ] 3.3 Write `personas/personal/tests/conftest.py` — minimal fixtures that
-  expose `persona_root = Path(__file__).resolve().parents[1]` and optionally
-  `parent_roles_dir` (None if not present). Zero imports from `assistant.*`.
+- [ ] 3.3 Write `personas/personal/tests/conftest.py` — minimal fixtures
+  that expose `persona_root = Path(__file__).resolve().parents[1]` and
+  optionally `parent_roles_dir` (None if not present). Zero imports from
+  `assistant.*`.
   **Spec scenarios**: test-privacy-boundary/self-contained-persona-submodule-test-suite
-  (submodule-tests-run-standalone)
+  (submodule-pyproject-declares-an-isolated-workspace)
   **Contracts**: n/a
   **Design decisions**: D3, D5
   **Dependencies**: 3.1, 3.2
 
-- [ ] 3.4 Write `personas/personal/pyproject.toml` — declare `pytest>=8` and
-  `pyyaml>=6` as dev dependencies. No `build-backend`; this is not an
-  installable package per D4.
+- [ ] 3.4 Write `personas/personal/pyproject.toml` — declare `pytest>=8`
+  and `pyyaml>=6` as dev dependencies, plus a `[tool.uv]` block declaring
+  the directory as a non-package and explicitly empty
+  `workspace.members = []`. This prevents `uv` from walking up to discover
+  the parent project (Round 1 finding A1).
   **Spec scenarios**: test-privacy-boundary/self-contained-persona-submodule-test-suite
-  (submodule-tests-run-standalone)
+  (submodule-pyproject-declares-an-isolated-workspace)
   **Contracts**: n/a
   **Design decisions**: D4
   **Dependencies**: none
 
-- [ ] 3.5 Write assertion (as a meta-test at
-  `personas/personal/tests/test_no_assistant_import.py`) that greps every
-  `*.py` under `personas/personal/tests/` and fails if any contains
-  `import assistant`, `from assistant`, or `from src.assistant`.
+- [ ] 3.5 Write `personas/personal/tests/test_no_assistant_import.py` with
+  TWO checks (Round 1 finding A1):
+  (a) **Static**: grep every `*.py` under `personas/personal/tests/` and
+      fail if any contains `import assistant`, `from assistant`,
+      `from src.assistant`, `__import__("assistant")`, or
+      `importlib.import_module("assistant")` outside this very file.
+  (b) **Runtime positive assertion**:
+      `with pytest.raises(ImportError): importlib.import_module("assistant")`.
+      This proves the venv truly does not have `assistant` installed; the
+      static check alone is bypassable via dynamic import idioms.
   **Spec scenarios**: test-privacy-boundary/self-contained-persona-submodule-test-suite
-  (submodule-tests-run-standalone)
+  (submodule-tests-assert-assistant-import-fails-at-runtime)
   **Contracts**: n/a
-  **Design decisions**: D3
+  **Design decisions**: D3, D4
   **Dependencies**: 3.3
 
-- [ ] 3.6 Verification: `cd personas/personal && uv run pytest tests/` exits
-  0. Also verify `PYTHONPATH=/dev/null uv run pytest personas/personal/tests/`
-  (proof of standalone) exits 0.
+- [ ] 3.6 Verification — fresh-venv standalone proof. Replaces the
+  `PYTHONPATH=/dev/null` approach (Round 1 finding A1, also acknowledged
+  by F1 with regard to root-pytest testpaths). Create a script
+  `scripts/verify-submodule-standalone.sh` that:
+  (1) creates a fresh venv: `python -m venv /tmp/spb-venv`,
+  (2) installs only pytest + pyyaml: `/tmp/spb-venv/bin/pip install pytest pyyaml`,
+  (3) runs `/tmp/spb-venv/bin/pytest personas/personal/tests/`,
+  (4) asserts exit status 0,
+  (5) cleans up via `trap`.
+  Also independently verify `cd personas/personal && uv run pytest tests/`
+  succeeds when the submodule is consumed in-place from a parent checkout.
   **Spec scenarios**: test-privacy-boundary/self-contained-persona-submodule-test-suite
-  (submodule-tests-run-standalone)
+  (standalone-proof-verification-uses-a-fresh-venv,
+  submodule-pyproject-declares-an-isolated-workspace)
   **Contracts**: n/a
-  **Design decisions**: D3
+  **Design decisions**: D4
   **Dependencies**: 3.1, 3.2, 3.3, 3.4, 3.5
 
 ## Phase 4 — CI and documentation
 
-- [ ] 4.1 Remove the `populate personas/personal from test fixture` step from
-  `.github/workflows/ci.yml` (lines 41-44 per the CI investigation).
-  **Spec scenarios**: test-privacy-boundary/ci-simplification
+- [ ] 4.1 Remove the `populate personas/personal from test fixture` step
+  from `.github/workflows/ci.yml` (lines 41-44 per the CI investigation).
+  **Spec scenarios**: test-privacy-boundary/ci-simplification-and-forward-compatible-hygiene-check
   (ci-omits-the-populate-personas-step)
   **Contracts**: n/a
-  **Design decisions**: D6 (remove, not keep as safety net)
-  **Dependencies**: 2.4
+  **Design decisions**: D6
+  **Dependencies**: 2.2 (fixture repoint must land first so CI remains
+  green after this step is removed)
 
 - [ ] 4.2 Add a new gotcha entry `G6: Private-persona content leakage via
   public test assertions` to `docs/gotchas.md` following the existing
-  symptom/root-cause/fix/prevention format.
+  symptom/root-cause/fix/prevention format. Cover both the literal-path
+  leak (Layer 1 catches) and the path-construction leak (Layer 2 catches).
+  Also document `ALLOW_STANDALONE_SUBMODULE_SKIP=1` and the workflow-
+  hygiene test as related entries (G7).
   **Spec scenarios**: test-privacy-boundary/documentation-of-the-privacy-boundary-rule
   (docs-gotchas-md-records-the-failure-mode)
   **Contracts**: n/a
   **Design decisions**: none
-  **Dependencies**: 2.2
+  **Dependencies**: 2.12, 2.13
 
-- [ ] 4.3 Update `CLAUDE.md` "Conventions" section with the bullet: "Public
-  tests use fixtures only (`tests/fixtures/personas/`); persona-specific
-  tests live in each persona's private submodule and must be self-contained
-  (no imports from `src/assistant/*`)."
+- [ ] 4.3 Update `CLAUDE.md` "Conventions" section with the bullet:
+  "Public tests use fixtures only (`tests/fixtures/personas/`);
+  persona-specific tests live in each persona's private submodule and
+  must be self-contained (no imports from `src/assistant/*`); the
+  two-layer privacy guard in `tests/conftest.py` enforces this at
+  collection time and at runtime."
   **Spec scenarios**: test-privacy-boundary/documentation-of-the-privacy-boundary-rule
   (claude-md-records-the-convention)
   **Contracts**: n/a
   **Design decisions**: none
   **Dependencies**: none
 
+- [ ] 4.4 Write `tests/test_ci_workflow_hygiene.py` — scans every
+  `.github/workflows/*.yml` for references to `personas/personal/` or
+  `personas/work/`. Fails if any reference is not paired with an explicit
+  copy-from-`tests/fixtures/` step (or if any `.yml` mentions the
+  forbidden path at all, since after D6 there should be zero such
+  references). Catches the regression class flagged by Round 1 finding A7.
+  **Spec scenarios**: test-privacy-boundary/ci-simplification-and-forward-compatible-hygiene-check
+  (workflow-hygiene-test-rejects-future-leakage-paths)
+  **Contracts**: n/a
+  **Design decisions**: R4
+  **Dependencies**: 2.10 (uses the same FORBIDDEN_PATH_NAMES constants),
+  4.1
+
 ## Phase 5 — Integration
 
-- [ ] 5.1 Run `openspec validate test-privacy-boundary --strict` and fix any
-  validation errors.
+- [ ] 5.1 Run `openspec validate test-privacy-boundary --strict` and fix
+  any validation errors.
   **Spec scenarios**: n/a
   **Contracts**: n/a
   **Design decisions**: none
   **Dependencies**: all of Phase 2, 3, 4
 
-- [ ] 5.2 Run full `uv run pytest` at the repo root — all tests green.
-  **Spec scenarios**: all
+- [ ] 5.2a Run `uv run pytest tests/` from repo root (covers Phase 2 +
+  Phase 4 work, exercises both guard layers and the workflow-hygiene
+  test). Must exit 0.
+  **Spec scenarios**: test-privacy-boundary/public-test-fixture-root,
+  test-privacy-boundary/two-layer-collection-time-and-runtime-boundary-guard,
+  test-privacy-boundary/ci-simplification-and-forward-compatible-hygiene-check
   **Contracts**: n/a
   **Design decisions**: none
-  **Dependencies**: 2.9, 3.6, 4.1, 4.2, 4.3
+  **Dependencies**: 2.14, 4.4
 
-- [ ] 5.3 Commit submodule content inside `personas/personal/`, push to its
-  private remote (e.g. `github.com/jankneumann/agentic-assistant-config-personal`),
-  then `git add personas/personal` in the parent to update the submodule SHA
-  pointer. Commit parent changes.
+- [ ] 5.2b Run `bash scripts/verify-submodule-standalone.sh` (created in
+  3.6) — covers Phase 3. Pyproject's `testpaths = ["tests"]` scopes the
+  root-level pytest to `tests/`, so submodule tests **must** be run via
+  the dedicated script (Round 1 finding F1).
+  **Spec scenarios**: test-privacy-boundary/self-contained-persona-submodule-test-suite
+  (all)
+  **Contracts**: n/a
+  **Design decisions**: D4
+  **Dependencies**: 3.6
+
+- [ ] 5.3a Inside the submodule, commit submodule content and push to its
+  private remote via `bash scripts/push-with-submodule.sh --submodule-only`
+  (or equivalent). This step lives in `wp-submodule-tests` (Round 1
+  finding F5/I3).
   **Spec scenarios**: n/a (ops)
   **Contracts**: n/a
-  **Design decisions**: D7 (submodule + parent as two commits)
-  **Dependencies**: 3.6, 5.2
+  **Design decisions**: D7
+  **Dependencies**: 5.2b
 
-- [ ] 5.4 Push parent branch `openspec/test-privacy-boundary` to origin and
-  open PR.
+- [ ] 5.3b In the parent repo, `git add personas/personal` to update the
+  submodule SHA pointer, commit, and push the parent branch via
+  `bash scripts/push-with-submodule.sh --parent-only`. Lives in
+  `wp-integration`. The atomic wrapper handles the failure mode where
+  parent push fails after submodule push succeeded (logs dangling SHA,
+  emits operator-recovery command — Round 1 finding A8).
+  **Spec scenarios**: n/a (ops)
+  **Contracts**: n/a
+  **Design decisions**: D7
+  **Dependencies**: 5.3a
+
+- [ ] 5.3-alt Fallback for missing private-repo write access (Round 1
+  finding I9): if 5.3a's push fails due to credential absence, the
+  dispatcher SHALL quarantine `wp-submodule-tests` with a clearly-flagged
+  status (`requires-private-repo-write`) and emit a handoff message
+  containing the exact `git -C personas/personal push <branch>` command
+  and the parent SHA-bump commit needed to follow up. The change is not
+  marked failed; it waits for an operator with credentials.
+  **Spec scenarios**: n/a (ops)
+  **Contracts**: n/a
+  **Design decisions**: R3
+  **Dependencies**: 5.3a (only fires on its failure)
+
+- [ ] 5.4 Push parent branch `openspec/test-privacy-boundary` to origin
+  and open PR. (Subsumed by 5.3b's `--parent-only` path; this task only
+  applies if 5.3b is split or skipped.)
   **Spec scenarios**: n/a (ops)
   **Contracts**: n/a
   **Design decisions**: none
-  **Dependencies**: 5.3
+  **Dependencies**: 5.3b

--- a/openspec/changes/test-privacy-boundary/validation-report.md
+++ b/openspec/changes/test-privacy-boundary/validation-report.md
@@ -1,0 +1,122 @@
+# Validation Report: test-privacy-boundary
+
+**Date**: 2026-04-13
+**Commit**: `c24c158`
+**Branch**: `openspec/test-privacy-boundary`
+**PR**: https://github.com/jankneumann/agentic-assistant/pull/2
+
+## Phase Results
+
+| Phase | Status | Evidence |
+|-------|--------|----------|
+| Prerequisites | ✓ pass | On `openspec/test-privacy-boundary`, 5 commits since `main`, submodule initialized |
+| Deploy | ○ skip | N/A — test-infrastructure feature, no HTTP API |
+| Smoke | ○ skip | N/A — no deployed service |
+| Gen-Eval | ○ skip | No descriptors found |
+| Security | ○ skip | N/A — no dependencies added; privacy-boundary is in-process only |
+| E2E | ○ skip | No `tests/e2e/` exists |
+| Architecture | ○ skip | `docs/architecture-analysis/` not scaffolded in this repo (tracked as gap) |
+| **Spec Compliance** | ✓ pass | 14/14 scenarios verified — see below |
+| Work-Package Evidence | ✓ pass | All packages completed; artifacts committed |
+| Log Analysis | ○ skip | No service logs (Deploy skipped) |
+| **CI/CD Status** | ✓ pass | PR #2: `Lint + typecheck + test` passed in 45s |
+
+## Spec Compliance Summary
+
+**All 14 SHALL/MUST scenarios are satisfied by the implementation.** Evidence per
+scenario is captured inline; full audit JSON recorded in the session log.
+
+### Requirement coverage
+
+| Requirement | Scenarios | Status |
+|-------------|-----------|--------|
+| Public test fixture root | 2/2 | ✓ |
+| Two-layer collection + runtime guard | 7/7 | ✓ |
+| Self-contained persona-submodule test suite | 4/4 | ✓ (including fresh-venv proof + parent-workspace forward-compat) |
+| Replacement integration coverage | 1/1 | ✓ (`FIXTURE_PERSONA_SENTINEL_v1` + `FIXTURE_ROLE_SENTINEL_v1`) |
+| CI simplification + hygiene check | 2/2 | ✓ |
+| Documentation | 2/2 | ✓ (`CLAUDE.md` Conventions + `docs/gotchas.md` G6/G7) |
+
+### Over-implementation (defense-in-depth beyond spec)
+
+1. **`ASSISTANT_PERSONAS_DIR` env-var contract** in `PersonaRegistry`/`RoleRegistry`
+   with precedence `explicit > env > default`, locked by 6 unit tests in
+   `tests/test_env_var_contract.py` and documented in `docs/gotchas.md` G6.
+2. **Idempotent `_install_patches`** (tests/_privacy_guard_plugin.py:235-249)
+   with dedicated regression test — defends against double `pytest_configure`
+   (xdist, re-registration) that would otherwise cause infinite recursion.
+3. **Symlink-escape resolve-pass** in `_is_forbidden` — catches
+   `tests/fixtures/sneaky → ../../personas/personal` bypass that the lexical
+   substring check would admit.
+4. **Component-aware subprocess argv matching** — catches `git -C
+   personas/personal log` (bare-dir) and `--config=.../personas/personal/...`
+   (colon-list) bypasses that simple substring matching would miss.
+5. **Plugin self-probe** at `pytest_configure` — fails session loudly if a
+   future CPython refuses Python-level rebinding of `Path.open`.
+
+### Spec drift (implementation evolved past spec; addressable in `/cleanup-feature`)
+
+| # | Drift | Resolution |
+|---|-------|------------|
+| 1 | `ASSISTANT_PERSONAS_DIR` env var is implemented + tested + documented in `docs/gotchas.md` G6 but not captured as a SHALL in `spec.md` | Add a scenario under "Public test fixture root" describing the precedence contract during spec-sync |
+| 2 | Subprocess interception covers `executable=` and `cwd=` kwargs (not just `args`); component-aware regex catches bare-dir argv | Add scenarios to "Layer 2 rejects a forbidden subprocess argv" |
+| 3 | Layer 1 `SCAN_EXCLUDED_FILES` includes `test_ci_workflow_hygiene.py` + `test_workspace_hygiene.py` (they reference forbidden names as data) | Document in D9 scope + add scenario |
+| 4 | Submodule conftest resolves parent root via `parents[3]` (conftest-relative), spec says `parents[2]` (test-file-relative) — both point to same directory but wording differs | Clarify spec phrasing |
+| 5 | `scripts/push-with-submodule.sh` exists as implementation-phase helper but no spec scenario governs it | Document as out-of-scope tooling OR add scenario for atomic dual-commit push |
+
+None of these drifts represent missing requirements — the implementation is
+stricter than the spec and tested accordingly. They are spec-grooming items
+that will make the spec reflect production reality.
+
+## Deferred (tracked, not blocking)
+
+- 15+ MINOR findings from IMPL_REVIEW Round 1 (perf polish, docstring drift,
+  commit split for bisect ergonomics, graphiti-contract positive assertion,
+  `os.open` perf short-circuit, missing-upstream error message clarity).
+  Captured in `openspec/changes/test-privacy-boundary/session-log.md` under
+  each review phase's "Open Questions".
+- Architecture graph (`docs/architecture-analysis/`) is absent in this repo —
+  unrelated to this change; tracked as a pre-existing gap.
+
+## Known limitations (documented in design R2, not blockers)
+
+Layer 2 runtime guard does NOT cover:
+- `mmap.mmap` on an already-opened file descriptor
+- `ctypes`-based I/O bypassing the stdlib
+- `os.system` on Windows (dispatches via `cmd.exe`, not `subprocess.Popen`)
+- Deliberately-split subprocess argv reconstructed at `execve` time
+
+These patterns are outside the documented threat model (deliberate evasion,
+not accidental Copilot idiom). Layer 1 substring scan is the only defense
+for any of them.
+
+## Verification commands (reproducible)
+
+```bash
+# Full parent-repo test suite
+uv run pytest tests/                      # 126 passed
+
+# Parent-repo tests with submodule deinit-ed (proves goal G1)
+bash scripts/verify-public-tests-standalone.sh  # 126 passed
+
+# Submodule self-contained suite in fresh venv (proves goal G3)
+bash scripts/verify-submodule-standalone.sh     # 9 passed
+
+# Static analysis
+uv run mypy src tests                     # 38 files, no issues
+uv run ruff check .                       # all checks passed
+
+# OpenSpec strict validation
+openspec validate test-privacy-boundary --strict
+```
+
+## Result
+
+**PASS — ready to merge.**
+
+Remaining work after merge:
+1. `/cleanup-feature test-privacy-boundary` — archives the change, syncs
+   spec delta into `openspec/specs/`, handles final submodule SHA
+   housekeeping on `main`.
+2. During spec-sync, resolve the 5 drift items above (most importantly,
+   capture the `ASSISTANT_PERSONAS_DIR` env-var contract as a SHALL).

--- a/openspec/changes/test-privacy-boundary/work-packages.yaml
+++ b/openspec/changes/test-privacy-boundary/work-packages.yaml
@@ -1,11 +1,13 @@
 # Work packages for test-privacy-boundary
 #
-# DAG:
+# DAG (post-Round-1):
 #   wp-contracts (root)
-#     ├─ wp-public-tests    (parallel)
-#     ├─ wp-submodule-tests (parallel; cross-repo — requires private-repo push)
-#     └─ wp-docs-ci         (parallel)
-#          └─ wp-integration (all three parallel packages merge here)
+#     ├─ wp-public-tests       (parallel; Phase 2 — scrub + guard + workflow-hygiene test)
+#     ├─ wp-submodule-tests    (parallel; cross-repo — requires private-repo write for 5.3a)
+#     └─ wp-docs               (parallel; CLAUDE.md + docs/gotchas.md only)
+#          └─ wp-ci-cleanup    (depends on wp-public-tests — task 4.1 needs the fixture
+#                              repoint to land first so CI stays green)
+#                ├─ wp-integration (merges everything; runs 5.2a; runs 5.3b parent SHA bump)
 
 packages:
   - id: wp-contracts
@@ -31,26 +33,55 @@ packages:
     verification: tier_c
 
   - id: wp-public-tests
-    name: "Public test boundary — repoint + scrub + guard"
+    name: "Public test boundary — sentinel, scrub, then two-layer guard"
     description: >-
-      Repoint the personas_dir fixture in tests/conftest.py to
-      tests/fixtures/personas/; scrub private-content assertions from public
-      tests; add pytest_collection_modifyitems guard. Includes Phase 2 tasks
-      (TDD ordering preserved: test tasks 2.1, 2.3 precede implementation
-      2.2, 2.4-2.8; verification 2.9 at end).
-    tasks: ["2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9"]
+      TDD-ordered Phase 2: add fixture sentinel (2.1), repoint personas_dir
+      (2.2), add fixture-based composition test (2.3), scrub legacy
+      assertions (2.4-2.8), verify with submodule-deinit script (2.9),
+      add deny-list config (2.10), test guard (2.11), implement Layer 1
+      collection-time hook (2.12) and Layer 2 runtime FS plugin (2.13),
+      final verification (2.14). Scrub-before-guard ordering is mandatory
+      (Round 1 finding I1). Includes the new helper script
+      scripts/verify-public-tests-standalone.sh.
+    tasks:
+      - "2.1"
+      - "2.2"
+      - "2.3"
+      - "2.4"
+      - "2.5"
+      - "2.6"
+      - "2.7"
+      - "2.8"
+      - "2.9"
+      - "2.10"
+      - "2.11"
+      - "2.12"
+      - "2.13"
+      - "2.14"
     priority: 2
     dependencies: ["wp-contracts"]
     scope:
       write_allow:
         - "tests/**"
+        - "scripts/verify-public-tests-standalone.sh"
       read_allow:
         - "src/**"
         - "roles/**"
         - "personas/_template/**"
         - "tests/fixtures/**"
+        # Read-only inspection of the real submodule mount is not needed
+        # by Phase 2 tasks; the deny-listed write paths below also exclude
+        # writes. Task 2.9 manipulates the submodule via `git submodule
+        # deinit`, which is a git-plumbing operation, not a write to the
+        # submodule's working tree contents (which belong to
+        # wp-submodule-tests). The git-plumbing happens through the parent
+        # .gitmodules / .git/modules state and is permitted.
       deny:
-        - "personas/personal/**"
+        - "personas/personal/persona.yaml"
+        - "personas/personal/prompt.md"
+        - "personas/personal/memory.md"
+        - "personas/personal/roles/**"
+        - "personas/personal/tests/**"
         - "personas/work/**"
         - ".github/**"
     locks:
@@ -61,25 +92,37 @@ packages:
         - "tests/test_persona_registry.py"
         - "tests/test_delegation.py"
         - "tests/test_cli.py"
+        - "tests/test_privacy_guard.py"
+        - "tests/test_ci_workflow_hygiene.py"
+        - "tests/_privacy_guard_config.py"
+        - "tests/_privacy_guard_plugin.py"
+        - "tests/fixtures/personas/personal/prompt.md"
+        - "tests/fixtures/personas/personal/roles/researcher.yaml"
+        - "scripts/verify-public-tests-standalone.sh"
       keys:
         - "tests:boundary:public"
-      ttl_minutes: 180
-      reason: "Public test scrub + guard hook"
+        - "tests:fixture:sentinel"
+      ttl_minutes: 240
+      reason: "Public test scrub + two-layer guard + workflow-hygiene"
     verification: tier_b
 
   - id: wp-submodule-tests
     name: "Self-contained persona-submodule test suite"
     description: >-
-      Inside personas/personal/ (private submodule, separate git repo), add
-      tests/ directory + pyproject.toml + conftest. All tests must be
-      self-contained — no imports from src/assistant/. Includes Phase 3
-      tasks (TDD ordering preserved).
-    tasks: ["3.1", "3.2", "3.3", "3.4", "3.5", "3.6"]
+      Inside personas/personal/ (private submodule, separate git repo),
+      add tests/ directory + pyproject.toml (with [tool.uv] workspace
+      isolation per D4) + conftest. All tests must be self-contained — no
+      imports from src/assistant/ — and the standalone-proof must use a
+      fresh venv (not PYTHONPATH=/dev/null). Includes Phase 3 tasks plus
+      the submodule-side commit+push 5.3a.
+    tasks: ["3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "5.2b", "5.3a", "5.3-alt"]
     priority: 2
     dependencies: ["wp-contracts"]
     scope:
       write_allow:
         - "personas/personal/**"
+        - "scripts/verify-submodule-standalone.sh"
+        - "scripts/push-with-submodule.sh"
       read_allow:
         - "roles/**"
         - "src/assistant/core/persona.py"
@@ -87,34 +130,71 @@ packages:
       deny:
         - "tests/**"
         - ".github/**"
+        - "personas/work/**"
     locks:
       files:
         - "personas/personal/pyproject.toml"
         - "personas/personal/tests/**"
+        - "scripts/verify-submodule-standalone.sh"
+        - "scripts/push-with-submodule.sh"
       keys:
         - "tests:boundary:submodule:personal"
-      ttl_minutes: 180
-      reason: "Persona-submodule self-contained test authoring (requires private-repo push access)"
+      ttl_minutes: 240
+      reason: "Persona-submodule self-contained test authoring + submodule-side push"
     verification: tier_b
     constraints:
-      # Non-standard field: implementation must have private-repo write access.
-      # Consuming skill (/implement-feature) should route this package to an
-      # agent that can authenticate to the private-repo remote.
+      # The work package writes to a path that is a git submodule mount.
+      # Implementer must `cd personas/personal` (or `git -C personas/personal
+      # ...`) for git operations; commits land in the submodule's own
+      # repo, not the parent. Task 5.3a pushes to the private remote.
+      cwd_for_git_ops: "personas/personal"
+      submodule_aware: true
       requires_private_repo_write: true
 
-  - id: wp-docs-ci
-    name: "CI simplification + documentation"
+  - id: wp-docs
+    name: "Documentation only"
     description: >-
-      Remove the populate-personas step from .github/workflows/ci.yml; add
-      docs/gotchas.md entry; update CLAUDE.md Conventions section.
-    tasks: ["4.1", "4.2", "4.3"]
+      Update CLAUDE.md Conventions section + add gotcha entries G6 and G7
+      to docs/gotchas.md. No CI changes (those are in wp-ci-cleanup).
+    tasks: ["4.2", "4.3"]
     priority: 2
     dependencies: ["wp-contracts"]
     scope:
       write_allow:
-        - ".github/workflows/ci.yml"
         - "docs/gotchas.md"
         - "CLAUDE.md"
+      read_allow:
+        - "openspec/changes/test-privacy-boundary/**"
+      deny:
+        - "tests/**"
+        - "personas/**"
+        - "src/**"
+        - ".github/**"
+    locks:
+      files:
+        - "docs/gotchas.md"
+        - "CLAUDE.md"
+      keys:
+        - "docs:gotchas"
+        - "docs:claude-md"
+      ttl_minutes: 60
+      reason: "Docs updates"
+    verification: tier_c
+
+  - id: wp-ci-cleanup
+    name: "CI workflow simplification"
+    description: >-
+      Remove the populate-personas step from .github/workflows/ci.yml
+      (task 4.1). Depends on wp-public-tests because task 4.1 requires
+      the fixture repoint (task 2.2) to have landed first, otherwise CI
+      breaks (Round 1 finding I4 — the dependency was previously hidden
+      inside tasks.md but not expressed at the package level).
+    tasks: ["4.1"]
+    priority: 3
+    dependencies: ["wp-public-tests"]
+    scope:
+      write_allow:
+        - ".github/workflows/ci.yml"
       read_allow:
         - "tests/conftest.py"
         - "openspec/changes/test-privacy-boundary/**"
@@ -122,41 +202,69 @@ packages:
         - "tests/**"
         - "personas/**"
         - "src/**"
+        - "docs/**"
+        - "CLAUDE.md"
     locks:
       files:
         - ".github/workflows/ci.yml"
-        - "docs/gotchas.md"
-        - "CLAUDE.md"
       keys:
         - "ci:workflow:main"
-        - "docs:gotchas"
-        - "docs:claude-md"
-      ttl_minutes: 90
-      reason: "CI cleanup + docs"
+      ttl_minutes: 60
+      reason: "CI cleanup, sequenced after fixture repoint"
     verification: tier_c
 
   - id: wp-integration
-    name: "Merge and full-suite verification"
+    name: "Merge, full-suite verification, parent push and PR"
     description: >-
-      Merge wp-public-tests, wp-submodule-tests, and wp-docs-ci branches.
-      Run openspec validate; run full pytest with submodule populated and
-      with submodule moved aside (standalone-proof); commit submodule SHA
-      bump; push branch and open PR.
-    tasks: ["5.1", "5.2", "5.3", "5.4"]
-    priority: 3
+      Validate, run full root-pytest (5.2a), run the openspec strict
+      check (5.1), update the parent's submodule SHA pointer (5.3b),
+      push the parent branch and open PR (5.4). The submodule-side
+      commit+push (5.3a) and standalone proof (5.2b) live in
+      wp-submodule-tests. wp-integration's role is parent-side glue.
+    tasks: ["5.1", "5.2a", "5.3b", "5.4"]
+    priority: 4
     dependencies:
       - "wp-public-tests"
       - "wp-submodule-tests"
-      - "wp-docs-ci"
+      - "wp-docs"
+      - "wp-ci-cleanup"
     scope:
+      # Tightened from "**" (Round 1 finding I8): wp-integration writes
+      # only to openspec/ for any --strict fixes, the parent .gitmodules
+      # state (via `git add personas/personal` for the gitlink), and any
+      # git history. It does NOT write submodule contents (those belong
+      # to wp-submodule-tests).
       write_allow:
-        - "**"
+        - "openspec/changes/test-privacy-boundary/**"
+        - ".gitmodules"
       read_allow:
         - "**"
+      deny:
+        - "personas/personal/persona.yaml"
+        - "personas/personal/prompt.md"
+        - "personas/personal/memory.md"
+        - "personas/personal/roles/**"
+        - "personas/personal/tests/**"
+        - "personas/personal/pyproject.toml"
+        - "tests/**"
+        - "src/**"
+        - ".github/**"
+        - "CLAUDE.md"
+        - "docs/**"
     locks:
       files: []
       keys:
         - "integration:test-privacy-boundary"
       ttl_minutes: 60
-      reason: "Integration merge + verification"
+      reason: "Integration merge + parent push"
     verification: tier_a
+    constraints:
+      # The parent push step (5.3b) updates the gitlink to the submodule
+      # SHA pushed by wp-submodule-tests. If that push hasn't completed
+      # (5.3-alt fallback fired), wp-integration must not run — declared
+      # via the wp-submodule-tests dependency above. Also: parent push
+      # may interact with branch protection on origin/openspec/* and
+      # requires write access to the parent remote (typically already
+      # available to any agent that cloned the parent).
+      requires_private_repo_write: true
+      requires_parent_push: true

--- a/openspec/changes/test-privacy-boundary/work-packages.yaml
+++ b/openspec/changes/test-privacy-boundary/work-packages.yaml
@@ -1,0 +1,162 @@
+# Work packages for test-privacy-boundary
+#
+# DAG:
+#   wp-contracts (root)
+#     ├─ wp-public-tests    (parallel)
+#     ├─ wp-submodule-tests (parallel; cross-repo — requires private-repo push)
+#     └─ wp-docs-ci         (parallel)
+#          └─ wp-integration (all three parallel packages merge here)
+
+packages:
+  - id: wp-contracts
+    name: "Contracts scaffold"
+    description: >-
+      Create contracts/README.md stub documenting that no API/DB/event
+      contract sub-types apply to this change.
+    tasks: ["1.1"]
+    priority: 1
+    dependencies: []
+    scope:
+      write_allow:
+        - "openspec/changes/test-privacy-boundary/contracts/**"
+      read_allow:
+        - "openspec/changes/test-privacy-boundary/**"
+    locks:
+      files:
+        - "openspec/changes/test-privacy-boundary/contracts/README.md"
+      keys:
+        - "docs:contracts:test-privacy-boundary"
+      ttl_minutes: 60
+      reason: "Contracts stub authoring"
+    verification: tier_c
+
+  - id: wp-public-tests
+    name: "Public test boundary — repoint + scrub + guard"
+    description: >-
+      Repoint the personas_dir fixture in tests/conftest.py to
+      tests/fixtures/personas/; scrub private-content assertions from public
+      tests; add pytest_collection_modifyitems guard. Includes Phase 2 tasks
+      (TDD ordering preserved: test tasks 2.1, 2.3 precede implementation
+      2.2, 2.4-2.8; verification 2.9 at end).
+    tasks: ["2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9"]
+    priority: 2
+    dependencies: ["wp-contracts"]
+    scope:
+      write_allow:
+        - "tests/**"
+      read_allow:
+        - "src/**"
+        - "roles/**"
+        - "personas/_template/**"
+        - "tests/fixtures/**"
+      deny:
+        - "personas/personal/**"
+        - "personas/work/**"
+        - ".github/**"
+    locks:
+      files:
+        - "tests/conftest.py"
+        - "tests/test_composition.py"
+        - "tests/test_role_registry.py"
+        - "tests/test_persona_registry.py"
+        - "tests/test_delegation.py"
+        - "tests/test_cli.py"
+      keys:
+        - "tests:boundary:public"
+      ttl_minutes: 180
+      reason: "Public test scrub + guard hook"
+    verification: tier_b
+
+  - id: wp-submodule-tests
+    name: "Self-contained persona-submodule test suite"
+    description: >-
+      Inside personas/personal/ (private submodule, separate git repo), add
+      tests/ directory + pyproject.toml + conftest. All tests must be
+      self-contained — no imports from src/assistant/. Includes Phase 3
+      tasks (TDD ordering preserved).
+    tasks: ["3.1", "3.2", "3.3", "3.4", "3.5", "3.6"]
+    priority: 2
+    dependencies: ["wp-contracts"]
+    scope:
+      write_allow:
+        - "personas/personal/**"
+      read_allow:
+        - "roles/**"
+        - "src/assistant/core/persona.py"
+        - "src/assistant/core/role.py"
+      deny:
+        - "tests/**"
+        - ".github/**"
+    locks:
+      files:
+        - "personas/personal/pyproject.toml"
+        - "personas/personal/tests/**"
+      keys:
+        - "tests:boundary:submodule:personal"
+      ttl_minutes: 180
+      reason: "Persona-submodule self-contained test authoring (requires private-repo push access)"
+    verification: tier_b
+    constraints:
+      # Non-standard field: implementation must have private-repo write access.
+      # Consuming skill (/implement-feature) should route this package to an
+      # agent that can authenticate to the private-repo remote.
+      requires_private_repo_write: true
+
+  - id: wp-docs-ci
+    name: "CI simplification + documentation"
+    description: >-
+      Remove the populate-personas step from .github/workflows/ci.yml; add
+      docs/gotchas.md entry; update CLAUDE.md Conventions section.
+    tasks: ["4.1", "4.2", "4.3"]
+    priority: 2
+    dependencies: ["wp-contracts"]
+    scope:
+      write_allow:
+        - ".github/workflows/ci.yml"
+        - "docs/gotchas.md"
+        - "CLAUDE.md"
+      read_allow:
+        - "tests/conftest.py"
+        - "openspec/changes/test-privacy-boundary/**"
+      deny:
+        - "tests/**"
+        - "personas/**"
+        - "src/**"
+    locks:
+      files:
+        - ".github/workflows/ci.yml"
+        - "docs/gotchas.md"
+        - "CLAUDE.md"
+      keys:
+        - "ci:workflow:main"
+        - "docs:gotchas"
+        - "docs:claude-md"
+      ttl_minutes: 90
+      reason: "CI cleanup + docs"
+    verification: tier_c
+
+  - id: wp-integration
+    name: "Merge and full-suite verification"
+    description: >-
+      Merge wp-public-tests, wp-submodule-tests, and wp-docs-ci branches.
+      Run openspec validate; run full pytest with submodule populated and
+      with submodule moved aside (standalone-proof); commit submodule SHA
+      bump; push branch and open PR.
+    tasks: ["5.1", "5.2", "5.3", "5.4"]
+    priority: 3
+    dependencies:
+      - "wp-public-tests"
+      - "wp-submodule-tests"
+      - "wp-docs-ci"
+    scope:
+      write_allow:
+        - "**"
+      read_allow:
+        - "**"
+    locks:
+      files: []
+      keys:
+        - "integration:test-privacy-boundary"
+      ttl_minutes: 60
+      reason: "Integration merge + verification"
+    verification: tier_a

--- a/openspec/changes/test-privacy-boundary/work-packages.yaml
+++ b/openspec/changes/test-privacy-boundary/work-packages.yaml
@@ -115,7 +115,7 @@ packages:
       imports from src/assistant/ — and the standalone-proof must use a
       fresh venv (not PYTHONPATH=/dev/null). Includes Phase 3 tasks plus
       the submodule-side commit+push 5.3a.
-    tasks: ["3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "5.2b", "5.3a", "5.3-alt"]
+    tasks: ["3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "5.0", "5.2b", "5.3a", "5.3-alt"]
     priority: 2
     dependencies: ["wp-contracts"]
     scope:
@@ -182,24 +182,39 @@ packages:
     verification: tier_c
 
   - id: wp-ci-cleanup
-    name: "CI workflow simplification"
+    name: "CI workflow simplification + hygiene tests"
     description: >-
       Remove the populate-personas step from .github/workflows/ci.yml
       (task 4.1). Depends on wp-public-tests because task 4.1 requires
       the fixture repoint (task 2.2) to have landed first, otherwise CI
-      breaks (Round 1 finding I4 — the dependency was previously hidden
-      inside tasks.md but not expressed at the package level).
-    tasks: ["4.1"]
+      breaks (Round 1 finding I4). Also authors the two hygiene tests
+      (4.4 workflow-hygiene, 4.5 workspace-hygiene) that are sequenced
+      here rather than in wp-public-tests because 4.4 must RUN after
+      the populate-step removal in 4.1 to assert zero references.
+      Placing 4.4/4.5 here keeps the write scope honest: this package
+      writes to .github/workflows/ci.yml and to the two dedicated
+      hygiene test files only.
+    tasks: ["4.1", "4.4", "4.5"]
     priority: 3
     dependencies: ["wp-public-tests"]
     scope:
       write_allow:
         - ".github/workflows/ci.yml"
+        - "tests/test_ci_workflow_hygiene.py"
+        - "tests/test_workspace_hygiene.py"
       read_allow:
         - "tests/conftest.py"
+        - "tests/_privacy_guard_config.py"
         - "openspec/changes/test-privacy-boundary/**"
+        - "pyproject.toml"
+        - ".github/workflows/**"
       deny:
-        - "tests/**"
+        # Write-only to the two named hygiene files; all other tests/ paths
+        # are owned by wp-public-tests and must not be touched here.
+        - "tests/conftest.py"
+        - "tests/_privacy_guard_config.py"
+        - "tests/_privacy_guard_plugin.py"
+        - "tests/fixtures/**"
         - "personas/**"
         - "src/**"
         - "docs/**"
@@ -207,10 +222,13 @@ packages:
     locks:
       files:
         - ".github/workflows/ci.yml"
+        - "tests/test_ci_workflow_hygiene.py"
+        - "tests/test_workspace_hygiene.py"
       keys:
         - "ci:workflow:main"
-      ttl_minutes: 60
-      reason: "CI cleanup, sequenced after fixture repoint"
+        - "tests:hygiene"
+      ttl_minutes: 90
+      reason: "CI cleanup + hygiene tests, sequenced after fixture repoint"
     verification: tier_c
 
   - id: wp-integration

--- a/scripts/push-with-submodule.sh
+++ b/scripts/push-with-submodule.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# push-with-submodule.sh — atomic wrapper for the two-commit submodule
+# push topology (task 5.0, design D7).
+#
+# Usage:
+#   scripts/push-with-submodule.sh --submodule-only
+#   scripts/push-with-submodule.sh --parent-only
+#
+# Modes are intentionally separate invocations:
+#   --submodule-only   cd into personas/personal, git push, print pushed SHA.
+#   --parent-only      verify parent branch rebased onto origin/main,
+#                      git add personas/personal gitlink, commit w/ SHA
+#                      in message, push parent branch.
+#
+# Idempotency: re-invoking either mode with nothing to do is a no-op
+# exit 0. Safe to re-run after transient network failures.
+#
+# Exit-code contract:
+#   0   success (including "nothing to push")
+#   1   generic failure (git error, invalid state)
+#   2   usage error (bad or missing mode flag)
+#  47   parent push failed AFTER submodule push had succeeded —
+#       distinctive code that the 5.3-alt dispatcher recognizes and
+#       routes into the quarantine/operator-handoff path. The diagnostic
+#       names the dangling submodule SHA and a suggested recovery.
+
+set -euo pipefail
+
+MODE="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SUBMODULE_DIR="$REPO_ROOT/personas/personal"
+
+usage() {
+    echo "Usage: $0 --submodule-only | --parent-only" >&2
+    exit 2
+}
+
+case "$MODE" in
+    --submodule-only)
+        if [[ ! -d "$SUBMODULE_DIR" ]]; then
+            echo "ERROR: submodule dir not found at $SUBMODULE_DIR" >&2
+            exit 1
+        fi
+        cd "$SUBMODULE_DIR"
+
+        # Idempotency: nothing dirty in working tree AND nothing unpushed
+        # relative to upstream => no-op.
+        dirty="$(git status --porcelain)"
+        # `git log @{u}..` fails if no upstream is set; treat that as
+        # "needs push" (conservative — better to attempt and fail loudly
+        # than to silently no-op).
+        if unpushed="$(git log '@{u}..' --oneline 2>/dev/null)"; then
+            :
+        else
+            unpushed="needs-push-unknown-upstream"
+        fi
+
+        if [[ -z "$dirty" && -z "$unpushed" ]]; then
+            echo "Submodule: nothing to push (working tree clean, upstream in sync)"
+            SHA="$(git rev-parse HEAD)"
+            echo "$SHA"
+            exit 0
+        fi
+
+        if [[ -n "$dirty" ]]; then
+            echo "ERROR: submodule working tree is dirty; commit before pushing" >&2
+            echo "$dirty" >&2
+            exit 1
+        fi
+
+        git push
+        SHA="$(git rev-parse HEAD)"
+        echo "Submodule pushed: $SHA"
+        echo "$SHA"
+        ;;
+
+    --parent-only)
+        cd "$REPO_ROOT"
+
+        # Verify parent branch is rebased onto origin/main before bumping
+        # the submodule gitlink.
+        git fetch origin main
+        if ! git merge-base --is-ancestor origin/main HEAD; then
+            echo "ERROR: parent branch is not rebased onto origin/main" >&2
+            echo "Run: git rebase origin/main" >&2
+            exit 1
+        fi
+
+        # Stage the submodule gitlink update (if any).
+        git add personas/personal
+
+        if git diff --cached --quiet personas/personal; then
+            echo "Parent: no submodule SHA change staged (gitlink already current)"
+        else
+            SUB_SHA="$(git -C "$SUBMODULE_DIR" rev-parse HEAD)"
+            git commit -m "chore(submodule): bump personas/personal to $SUB_SHA"
+        fi
+
+        # Attempt parent push. If this fails after we have already pushed
+        # the submodule (via an earlier --submodule-only invocation),
+        # emit the dangling-SHA diagnostic and exit 47.
+        if ! git push 2>&1; then
+            DANGLING_SHA="$(git -C "$SUBMODULE_DIR" rev-parse HEAD)"
+            echo "" >&2
+            echo "ERROR: parent push FAILED after submodule push had succeeded" >&2
+            echo "Dangling submodule SHA: $DANGLING_SHA" >&2
+            echo "" >&2
+            echo "Recovery options:" >&2
+            echo "  1. Rebase the parent branch and re-run --parent-only:" >&2
+            echo "       git fetch origin main && git rebase origin/main" >&2
+            echo "       bash scripts/push-with-submodule.sh --parent-only" >&2
+            echo "  2. If the submodule SHA must be retracted, delete the" >&2
+            echo "     remote ref from the private submodule host:" >&2
+            echo "       git -C personas/personal push -d origin <branch-with-dangling-sha>" >&2
+            echo "  3. Or open an operator ticket with the SHA above." >&2
+            exit 47
+        fi
+
+        echo "Parent pushed."
+        ;;
+
+    *)
+        usage
+        ;;
+esac

--- a/scripts/push-with-submodule.sh
+++ b/scripts/push-with-submodule.sh
@@ -97,24 +97,39 @@ case "$MODE" in
             git commit -m "chore(submodule): bump personas/personal to $SUB_SHA"
         fi
 
-        # Attempt parent push. If this fails after we have already pushed
-        # the submodule (via an earlier --submodule-only invocation),
-        # emit the dangling-SHA diagnostic and exit 47.
+        # Attempt parent push. Exit-47 is reserved specifically for the
+        # "submodule already pushed, parent failed" dangling-SHA case so
+        # the 5.3-alt dispatcher can distinguish operator-handoff from
+        # benign push failures (IR-B1). Check whether the submodule
+        # SHA is reachable on its remote BEFORE classifying the failure.
         if ! git push 2>&1; then
-            DANGLING_SHA="$(git -C "$SUBMODULE_DIR" rev-parse HEAD)"
+            SUB_SHA="$(git -C "$SUBMODULE_DIR" rev-parse HEAD)"
+            # Is the submodule SHA reachable on any remote ref?
+            if git -C "$SUBMODULE_DIR" fetch --quiet 2>/dev/null \
+                && git -C "$SUBMODULE_DIR" branch -r --contains "$SUB_SHA" 2>/dev/null \
+                | grep -q .; then
+                # Genuine dangling-SHA scenario: submodule push had
+                # succeeded; parent push failed. Route to 5.3-alt.
+                echo "" >&2
+                echo "ERROR: parent push FAILED after submodule push had succeeded" >&2
+                echo "Dangling submodule SHA: $SUB_SHA" >&2
+                echo "" >&2
+                echo "Recovery options:" >&2
+                echo "  1. Rebase the parent branch and re-run --parent-only:" >&2
+                echo "       git fetch origin main && git rebase origin/main" >&2
+                echo "       bash scripts/push-with-submodule.sh --parent-only" >&2
+                echo "  2. If the submodule SHA must be retracted, delete the" >&2
+                echo "     remote ref from the private submodule host:" >&2
+                echo "       git -C personas/personal push -d origin <branch-with-dangling-sha>" >&2
+                echo "  3. Or open an operator ticket with the SHA above." >&2
+                exit 47
+            fi
+            # Submodule SHA is NOT pushed yet: benign parent failure.
             echo "" >&2
-            echo "ERROR: parent push FAILED after submodule push had succeeded" >&2
-            echo "Dangling submodule SHA: $DANGLING_SHA" >&2
-            echo "" >&2
-            echo "Recovery options:" >&2
-            echo "  1. Rebase the parent branch and re-run --parent-only:" >&2
-            echo "       git fetch origin main && git rebase origin/main" >&2
-            echo "       bash scripts/push-with-submodule.sh --parent-only" >&2
-            echo "  2. If the submodule SHA must be retracted, delete the" >&2
-            echo "     remote ref from the private submodule host:" >&2
-            echo "       git -C personas/personal push -d origin <branch-with-dangling-sha>" >&2
-            echo "  3. Or open an operator ticket with the SHA above." >&2
-            exit 47
+            echo "ERROR: parent push failed (submodule SHA $SUB_SHA is not" >&2
+            echo "       yet on the submodule remote; not a dangling-SHA case)." >&2
+            echo "Run --submodule-only first, then retry --parent-only." >&2
+            exit 1
         fi
 
         echo "Parent pushed."

--- a/scripts/verify-public-tests-standalone.sh
+++ b/scripts/verify-public-tests-standalone.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Verify public tests pass without the private personas/personal submodule
+# being populated (spec: test-privacy-boundary / public-test-fixture-root:
+# "Public test suite passes without submodule content").
+#
+# Strategy:
+#   1. git submodule deinit -f personas/personal  (leaves mount empty)
+#   2. uv run pytest tests/                        (public suite against
+#                                                   fixtures only)
+#   3. Restore via trap:  git submodule update --init personas/personal
+#
+# The `trap ... EXIT` guarantees restoration even on pytest failure or
+# user interrupt. Replaces the unsafe `mv` approach rejected in Round 1
+# (finding I5).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+SUBMODULE="personas/personal"
+
+restore() {
+    # Best-effort restore; don't mask the original exit code.
+    local rc=$?
+    echo "[verify-public-tests] restoring submodule $SUBMODULE..." >&2
+    git submodule update --init "$SUBMODULE" >/dev/null 2>&1 || \
+        echo "[verify-public-tests] WARNING: submodule restore failed; run 'git submodule update --init $SUBMODULE' manually" >&2
+    exit "$rc"
+}
+trap restore EXIT INT TERM
+
+echo "[verify-public-tests] deiniting $SUBMODULE..."
+git submodule deinit -f "$SUBMODULE"
+
+echo "[verify-public-tests] running uv run pytest tests/..."
+uv run pytest tests/

--- a/scripts/verify-submodule-standalone.sh
+++ b/scripts/verify-submodule-standalone.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# verify-submodule-standalone.sh — fresh-venv standalone proof for the
+# personas/personal submodule test suite (task 3.6, design D4).
+#
+# Contract:
+#   1. Create a fresh venv at a unique path.
+#   2. Install ONLY pytest>=8 and pyyaml>=6 (pinned minimums per B-N7).
+#   3. cd into personas/personal BEFORE invoking pytest so rootdir is the
+#      submodule's pyproject.toml, not the parent repo's (Round 2 B-N7).
+#   4. Run pytest with --override-ini='addopts=' to defeat any inherited
+#      addopts from the parent's pytest config.
+#   5. Clean up the venv via trap on EXIT / INT / TERM.
+#
+# Exit 0 on pass; non-zero on any failure (pytest or setup).
+
+set -euo pipefail
+
+VENV="/tmp/spb-venv-$$"
+
+cleanup() {
+    rm -rf "$VENV"
+}
+trap cleanup EXIT INT TERM
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SUBMODULE_DIR="$REPO_ROOT/personas/personal"
+
+if [[ ! -d "$SUBMODULE_DIR" ]]; then
+    echo "ERROR: submodule dir not found at $SUBMODULE_DIR" >&2
+    exit 1
+fi
+
+echo "Creating fresh venv at $VENV ..."
+python3 -m venv "$VENV"
+
+echo "Installing pytest>=8 and pyyaml>=6 ..."
+"$VENV/bin/pip" install --quiet --upgrade pip
+"$VENV/bin/pip" install --quiet 'pytest>=8' 'pyyaml>=6'
+
+echo "Running submodule tests from $SUBMODULE_DIR ..."
+cd "$SUBMODULE_DIR"
+"$VENV/bin/pytest" tests/ --rootdir=. --override-ini='addopts=' -v
+
+echo ""
+echo "Submodule standalone verification PASSED"

--- a/src/assistant/core/persona.py
+++ b/src/assistant/core/persona.py
@@ -36,10 +36,23 @@ class PersonaConfig:
     raw: dict[str, Any] = field(default_factory=dict)
 
 
-class PersonaRegistry:
-    """Discover and load personas from submodule-mounted directories."""
+_DEFAULT_PERSONAS_DIR = Path("personas")
 
-    def __init__(self, personas_dir: Path | str = Path("personas")) -> None:
+
+class PersonaRegistry:
+    """Discover and load personas from submodule-mounted directories.
+
+    The root is resolved (in order): explicit ``personas_dir`` arg, the
+    ``ASSISTANT_PERSONAS_DIR`` environment variable, then ``Path("personas")``.
+    The env-var path lets tests and alternative harnesses redirect the
+    registry away from the production submodule mount without touching
+    callers — see docs/gotchas.md G6 for the privacy-boundary rationale.
+    """
+
+    def __init__(self, personas_dir: Path | str | None = None) -> None:
+        if personas_dir is None:
+            env = os.environ.get("ASSISTANT_PERSONAS_DIR")
+            personas_dir = Path(env) if env else _DEFAULT_PERSONAS_DIR
         self.personas_dir = Path(personas_dir)
         self._cache: dict[str, PersonaConfig] = {}
 

--- a/src/assistant/core/role.py
+++ b/src/assistant/core/role.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -37,9 +38,18 @@ class RoleRegistry:
 
     def __init__(
         self,
-        roles_dir: Path | str = Path("roles"),
-        personas_dir: Path | str = Path("personas"),
+        roles_dir: Path | str | None = None,
+        personas_dir: Path | str | None = None,
     ) -> None:
+        # Honor ASSISTANT_PERSONAS_DIR for test-privacy-boundary (see
+        # PersonaRegistry.__init__ and docs/gotchas.md G6). The env var
+        # redirects both the persona base config and its role overrides
+        # so tests never read from `personas/<name>/` at runtime.
+        if personas_dir is None:
+            env = os.environ.get("ASSISTANT_PERSONAS_DIR")
+            personas_dir = Path(env) if env else Path("personas")
+        if roles_dir is None:
+            roles_dir = Path("roles")
         self.roles_dir = Path(roles_dir)
         self.personas_dir = Path(personas_dir)
 

--- a/tests/_privacy_guard_config.py
+++ b/tests/_privacy_guard_config.py
@@ -1,0 +1,60 @@
+"""Single source of truth for the two-layer privacy-boundary guard.
+
+Layer 1 (collection-time substring scan in ``tests/conftest.py``) and Layer 2
+(runtime FS-I/O patching in ``tests/_privacy_guard_plugin.py``) both read
+from the constants defined here. Adding a new persona name (e.g. when P6
+populates ``personas/work/``) is a one-line change here, not two.
+
+This module is intentionally NOT a conftest and NOT a test module. It is
+imported by the guard infrastructure; pytest never collects it.
+
+See ``openspec/changes/test-privacy-boundary/design.md`` D2, D8, D9 for the
+rationale behind each constant.
+"""
+
+from __future__ import annotations
+
+# Persona names that public tests are forbidden from reading from at
+# ``personas/<name>/``. Currently covers ``personal`` (populated submodule)
+# and ``work`` (future P6 populated submodule) — future-proofs the guard
+# so adding ``work`` later is one line.
+FORBIDDEN_PATH_NAMES: tuple[str, ...] = ("personal", "work")
+
+# Read-path prefixes that ARE allowed to resolve under ``personas/<name>/``
+# (or elsewhere). ``tests/fixtures/`` is the public-test persona root after
+# repoint (task 2.2). ``personas/_template/`` is public-by-design template
+# content that new personas scaffold from.
+ALLOWED_READ_PREFIXES: tuple[str, ...] = (
+    "tests/fixtures/",
+    "personas/_template/",
+)
+
+# Files that Layer 1 (collection-time substring scan) SHALL NOT inspect.
+# These files legitimately contain forbidden substrings as *data* (the
+# guard implementation, deny-list config, and hygiene tests that scan
+# workflow / pyproject YAML for leakage) — they do not constitute a
+# privacy-boundary violation. The hygiene tests additionally construct
+# their forbidden needles dynamically from FORBIDDEN_PATH_NAMES so a
+# naive contributor can't accidentally reintroduce a literal substring
+# (belt-and-suspenders per D9).
+#
+# Paths are repo-root-relative POSIX strings; the Layer 1 hook compares
+# via ``pathlib.PurePath.as_posix()``.
+SCAN_EXCLUDED_FILES: tuple[str, ...] = (
+    "tests/_privacy_guard_config.py",
+    "tests/_privacy_guard_plugin.py",
+    "tests/test_ci_workflow_hygiene.py",
+    "tests/test_workspace_hygiene.py",
+)
+
+# Directories that Layer 1 SHALL NOT inspect. ``tests/fixtures/`` is the
+# public-test fixture tree (Layer 1 scans only Python test/conftest files,
+# but fixtures can contain YAML/Markdown with forbidden-looking strings
+# that are in fact fixture content — defensive exclusion). ``tests/_helpers/``
+# is the documented location for non-test Python helpers per D8.
+#
+# Paths are repo-root-relative POSIX strings with trailing slash.
+SCAN_EXCLUDED_DIRS: tuple[str, ...] = (
+    "tests/fixtures/",
+    "tests/_helpers/",
+)

--- a/tests/_privacy_guard_plugin.py
+++ b/tests/_privacy_guard_plugin.py
@@ -1,0 +1,300 @@
+"""Layer 2 runtime filesystem guard for the privacy boundary.
+
+This pytest plugin patches the canonical I/O entry points for the duration
+of a pytest session so that any read of a path under ``personas/<name>/``
+(for ``<name>`` in ``FORBIDDEN_PATH_NAMES``) raises
+``_PrivacyBoundaryViolation`` unless the path falls under an
+``ALLOWED_READ_PREFIXES`` entry.
+
+Patched entry points (per design D1 + Round 2 findings B-N1/B-N2):
+
+- ``pathlib.Path.open``, ``Path.read_text``, ``Path.read_bytes``
+- ``builtins.open``
+- ``os.open``                         -- canonical syscall choke point
+- ``subprocess.Popen.__init__``       -- argv scan for forbidden substrings
+
+A self-probe at ``pytest_configure`` verifies the patches are active
+(B-N8); if a future CPython refuses Python-level rebinding of a C-slot
+method the session fails loudly rather than silently passing.
+
+Originals are restored at ``pytest_unconfigure``.
+
+Wired in via ``pytest_plugins = ["tests._privacy_guard_plugin"]`` in
+``tests/conftest.py``.
+"""
+
+from __future__ import annotations
+
+import builtins
+import os
+import pathlib
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests._privacy_guard_config import (
+    ALLOWED_READ_PREFIXES,
+    FORBIDDEN_PATH_NAMES,
+)
+
+
+class _PrivacyBoundaryViolation(pytest.UsageError):  # type: ignore[misc]
+    """Raised when a Layer 2 patched I/O entry point sees a forbidden read.
+
+    ``pytest.UsageError`` is declared ``@final`` in pytest's type stubs,
+    but at runtime it is a plain exception class and subclassing works.
+    We accept the mypy suppression here to preserve the
+    "subclass-of-UsageError" contract that pytest's own session-fail
+    machinery recognizes.
+    """
+
+
+# Resolved at pytest_configure; used to turn absolute paths back into
+# repo-root-relative POSIX strings for prefix comparison.
+_REPO_ROOT: Path | None = None
+
+# Cached saved originals; populated at pytest_configure.
+_ORIGINALS: dict[str, Any] = {}
+
+
+def _forbidden_needles() -> tuple[str, ...]:
+    """Return the POSIX substrings that indicate a forbidden path.
+
+    Computed from ``FORBIDDEN_PATH_NAMES`` so adding a persona name to the
+    deny-list auto-updates every check site.
+    """
+    return tuple(f"personas/{name}/" for name in FORBIDDEN_PATH_NAMES)
+
+
+def _allowed_prefixes() -> tuple[str, ...]:
+    return ALLOWED_READ_PREFIXES
+
+
+def _normalize(path: Any) -> str:
+    """Return a POSIX-shaped path string for comparison.
+
+    - Absolute paths under ``_REPO_ROOT`` are stripped to repo-relative.
+    - PathLike and bytes are coerced to ``str``.
+    - Unresolvable inputs fall back to ``str(path)``.
+    """
+    # bytes -> str
+    if isinstance(path, (bytes, bytearray)):
+        try:
+            path = path.decode("utf-8", errors="replace")
+        except Exception:  # pragma: no cover -- defensive
+            path = str(path)
+    # PathLike -> str
+    if hasattr(path, "__fspath__"):
+        try:
+            path = os.fspath(path)
+        except Exception:  # pragma: no cover -- defensive
+            path = str(path)
+    if not isinstance(path, str):
+        path = str(path)
+    posix = path.replace("\\", "/")
+    if _REPO_ROOT is not None:
+        # If the path resolves (or lexically lives) under repo-root, strip it.
+        try:
+            resolved = Path(path)
+            if not resolved.is_absolute():
+                resolved = _REPO_ROOT / resolved
+            # Avoid touching the filesystem for .resolve(); use normalization
+            # so a nonexistent path still participates in the comparison.
+            abs_posix = os.path.normpath(str(resolved)).replace("\\", "/")
+            root_posix = os.path.normpath(str(_REPO_ROOT)).replace("\\", "/")
+            if abs_posix.startswith(root_posix + "/"):
+                posix = abs_posix[len(root_posix) + 1 :]
+            elif abs_posix == root_posix:
+                posix = ""
+        except Exception:  # pragma: no cover -- defensive
+            pass
+    return posix
+
+
+def _is_forbidden(path: Any) -> tuple[bool, str, str]:
+    """Return ``(is_forbidden, needle, normalized_path)``.
+
+    A path is forbidden iff it contains a needle from
+    ``_forbidden_needles()`` AND does NOT start with any allow-list prefix.
+    """
+    normalized = _normalize(path)
+    # Allow-list short-circuit.
+    for prefix in _allowed_prefixes():
+        if normalized.startswith(prefix):
+            return False, "", normalized
+    for needle in _forbidden_needles():
+        if needle in normalized:
+            return True, needle, normalized
+    return False, "", normalized
+
+
+def _violate(path: Any, needle: str, normalized: str) -> None:
+    """Raise ``_PrivacyBoundaryViolation`` identifying the matched needle.
+
+    Deliberately does NOT echo file contents (spec scenario "Guard failure
+    messages do not echo private payloads").
+    """
+    raise _PrivacyBoundaryViolation(
+        "Privacy-boundary violation: runtime read of "
+        f"{normalized!r} matched forbidden path prefix {needle!r}. "
+        "Public tests must use tests/fixtures/ instead. "
+        "See docs/gotchas.md G6."
+    )
+
+
+# ── Patched entry points ────────────────────────────────────────────────
+
+
+def _patched_path_open(self: Path, *args: Any, **kwargs: Any) -> Any:
+    forbidden, needle, normalized = _is_forbidden(self)
+    if forbidden:
+        _violate(self, needle, normalized)
+    return _ORIGINALS["path_open"](self, *args, **kwargs)
+
+
+def _patched_path_read_text(self: Path, *args: Any, **kwargs: Any) -> Any:
+    forbidden, needle, normalized = _is_forbidden(self)
+    if forbidden:
+        _violate(self, needle, normalized)
+    return _ORIGINALS["path_read_text"](self, *args, **kwargs)
+
+
+def _patched_path_read_bytes(self: Path, *args: Any, **kwargs: Any) -> Any:
+    forbidden, needle, normalized = _is_forbidden(self)
+    if forbidden:
+        _violate(self, needle, normalized)
+    return _ORIGINALS["path_read_bytes"](self, *args, **kwargs)
+
+
+def _patched_builtins_open(file: Any, *args: Any, **kwargs: Any) -> Any:
+    forbidden, needle, normalized = _is_forbidden(file)
+    if forbidden:
+        _violate(file, needle, normalized)
+    return _ORIGINALS["builtins_open"](file, *args, **kwargs)
+
+
+def _patched_os_open(path: Any, *args: Any, **kwargs: Any) -> Any:
+    forbidden, needle, normalized = _is_forbidden(path)
+    if forbidden:
+        _violate(path, needle, normalized)
+    return _ORIGINALS["os_open"](path, *args, **kwargs)
+
+
+def _patched_popen_init(self: subprocess.Popen, *args: Any, **kwargs: Any) -> Any:
+    # First positional arg is ``args`` (argv list or string) per Popen API.
+    argv: Any = None
+    if args:
+        argv = args[0]
+    else:
+        argv = kwargs.get("args")
+    candidates: list[str] = []
+    if isinstance(argv, (list, tuple)):
+        for element in argv:
+            if isinstance(element, (bytes, bytearray)):
+                try:
+                    candidates.append(
+                        element.decode("utf-8", errors="replace")
+                    )
+                except Exception:
+                    candidates.append(str(element))
+            else:
+                candidates.append(str(element))
+    elif isinstance(argv, (str, bytes, bytearray)):
+        if isinstance(argv, (bytes, bytearray)):
+            try:
+                candidates.append(argv.decode("utf-8", errors="replace"))
+            except Exception:
+                candidates.append(str(argv))
+        else:
+            candidates.append(argv)
+    needles = _forbidden_needles()
+    for element in candidates:
+        posix_element = element.replace("\\", "/")
+        # Allow-list: a subprocess arg explicitly targeting fixtures is fine.
+        allowlisted = any(
+            prefix in posix_element for prefix in _allowed_prefixes()
+        )
+        if allowlisted:
+            continue
+        for needle in needles:
+            if needle in posix_element:
+                raise _PrivacyBoundaryViolation(
+                    "Privacy-boundary violation: subprocess argv element "
+                    f"{element!r} contained forbidden path prefix "
+                    f"{needle!r}. Public tests must use tests/fixtures/ "
+                    "instead. See docs/gotchas.md G6."
+                )
+    return _ORIGINALS["popen_init"](self, *args, **kwargs)
+
+
+# ── Install / uninstall / self-probe ────────────────────────────────────
+
+
+def _install_patches() -> None:
+    _ORIGINALS["path_open"] = pathlib.Path.open
+    _ORIGINALS["path_read_text"] = pathlib.Path.read_text
+    _ORIGINALS["path_read_bytes"] = pathlib.Path.read_bytes
+    _ORIGINALS["builtins_open"] = builtins.open
+    _ORIGINALS["os_open"] = os.open
+    _ORIGINALS["popen_init"] = subprocess.Popen.__init__
+
+    pathlib.Path.open = _patched_path_open  # type: ignore[method-assign]
+    pathlib.Path.read_text = _patched_path_read_text  # type: ignore[method-assign]
+    pathlib.Path.read_bytes = _patched_path_read_bytes  # type: ignore[method-assign]
+    builtins.open = _patched_builtins_open
+    os.open = _patched_os_open
+    subprocess.Popen.__init__ = _patched_popen_init  # type: ignore[method-assign]
+
+
+def _uninstall_patches() -> None:
+    if not _ORIGINALS:
+        return
+    pathlib.Path.open = _ORIGINALS["path_open"]  # type: ignore[method-assign]
+    pathlib.Path.read_text = _ORIGINALS["path_read_text"]  # type: ignore[method-assign]
+    pathlib.Path.read_bytes = _ORIGINALS["path_read_bytes"]  # type: ignore[method-assign]
+    builtins.open = _ORIGINALS["builtins_open"]
+    os.open = _ORIGINALS["os_open"]
+    subprocess.Popen.__init__ = _ORIGINALS["popen_init"]  # type: ignore[method-assign]
+    _ORIGINALS.clear()
+
+
+def _self_probe() -> None:
+    """Attempt a canary forbidden read; assert guard raises.
+
+    Uses ``Path.read_text`` on a canonically-forbidden nonexistent path.
+    If patches silently failed to install, the read would raise
+    ``FileNotFoundError`` (or succeed if the path exists) rather than
+    ``_PrivacyBoundaryViolation``. We detect either non-violation outcome
+    and fail the session.
+    """
+    # Build canary dynamically so this module's own source does NOT embed
+    # a forbidden literal.
+    canary_name = FORBIDDEN_PATH_NAMES[0] if FORBIDDEN_PATH_NAMES else "personal"
+    canary = Path("personas") / canary_name / "privacy-guard-canary-nonexistent"
+    try:
+        canary.read_text()
+    except _PrivacyBoundaryViolation:
+        return  # Guard is live -- correct outcome.
+    except BaseException:  # pragma: no cover -- indicates patch missed
+        pass
+    raise pytest.UsageError("Layer 2 privacy guard failed to install")
+
+
+# ── pytest hooks ────────────────────────────────────────────────────────
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    global _REPO_ROOT
+    # rootpath is pytest's resolved rootdir; the worktree root for us.
+    try:
+        _REPO_ROOT = Path(str(config.rootpath)).resolve()
+    except Exception:  # pragma: no cover -- fallback if rootpath absent
+        _REPO_ROOT = Path.cwd().resolve()
+    _install_patches()
+    _self_probe()
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    _uninstall_patches()

--- a/tests/_privacy_guard_plugin.py
+++ b/tests/_privacy_guard_plugin.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import builtins
 import os
 import pathlib
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -116,18 +117,68 @@ def _normalize(path: Any) -> str:
 def _is_forbidden(path: Any) -> tuple[bool, str, str]:
     """Return ``(is_forbidden, needle, normalized_path)``.
 
-    A path is forbidden iff it contains a needle from
-    ``_forbidden_needles()`` AND does NOT start with any allow-list prefix.
+    Two-pass check. First the lexical pass (cheap, covers the common
+    case). Then, only if the lexical pass didn't already conclude the
+    path is forbidden/allowed unambiguously, a resolve pass (IR-A3)
+    catches symlink-based bypasses like
+    ``tests/fixtures/sneaky -> ../../personas/personal``.
     """
     normalized = _normalize(path)
-    # Allow-list short-circuit.
+    # Lexical allow-list short-circuit. If the lexical path is allow-
+    # listed AND a symlink resolution stays within an allow-listed
+    # prefix, the read proceeds; if resolution escapes to a forbidden
+    # location, we reject.
     for prefix in _allowed_prefixes():
         if normalized.startswith(prefix):
+            resolved_posix = _resolve_relative_to_root(path)
+            if resolved_posix is None:
+                return False, "", normalized
+            # If the resolved path is ALSO under an allow-listed prefix,
+            # it's fine even if the normalized form contains a
+            # sub-string match for a forbidden name (legitimate case:
+            # tests/fixtures/personas/personal/*).
+            for allowed in _allowed_prefixes():
+                if resolved_posix.startswith(allowed):
+                    return False, "", normalized
+            # Resolved out of allow-list -- check for forbidden needles.
+            for needle in _forbidden_needles():
+                if needle in resolved_posix:
+                    return True, needle, resolved_posix
             return False, "", normalized
+    # Lexical forbidden check.
     for needle in _forbidden_needles():
         if needle in normalized:
             return True, needle, normalized
+    # Final resolve pass: catches cases where the lexical path didn't
+    # hit any needle but a symlink redirects to forbidden territory.
+    resolved_posix = _resolve_relative_to_root(path)
+    if resolved_posix is not None and resolved_posix != normalized:
+        for allowed in _allowed_prefixes():
+            if resolved_posix.startswith(allowed):
+                return False, "", normalized
+        for needle in _forbidden_needles():
+            if needle in resolved_posix:
+                return True, needle, resolved_posix
     return False, "", normalized
+
+
+def _resolve_relative_to_root(path: Any) -> str | None:
+    """Best-effort resolve to a repo-relative POSIX string; None on failure."""
+    try:
+        if isinstance(path, (int, bytes, bytearray)):
+            return None
+        p = Path(path) if not isinstance(path, Path) else path
+        resolved = p.resolve(strict=False)
+    except (OSError, ValueError, RuntimeError):
+        return None
+    posix = str(resolved).replace("\\", "/")
+    if _REPO_ROOT is not None:
+        root_posix = str(_REPO_ROOT).replace("\\", "/")
+        if posix.startswith(root_posix + "/"):
+            posix = posix[len(root_posix) + 1 :]
+        elif posix == root_posix:
+            posix = ""
+    return posix
 
 
 def _violate(path: Any, needle: str, normalized: str) -> None:
@@ -182,50 +233,90 @@ def _patched_os_open(path: Any, *args: Any, **kwargs: Any) -> Any:
     return _ORIGINALS["os_open"](path, *args, **kwargs)
 
 
-def _patched_popen_init(self: subprocess.Popen, *args: Any, **kwargs: Any) -> Any:
-    # First positional arg is ``args`` (argv list or string) per Popen API.
-    argv: Any = None
-    if args:
-        argv = args[0]
-    else:
-        argv = kwargs.get("args")
+def _decode_candidate(element: Any) -> str:
+    if isinstance(element, (bytes, bytearray)):
+        try:
+            return element.decode("utf-8", errors="replace")
+        except Exception:
+            return str(element)
+    return str(element)
+
+
+def _subprocess_candidates(args: tuple, kwargs: dict) -> list[str]:
+    """Harvest every string the subprocess could plausibly resolve to a path.
+
+    Covers the positional ``args`` argv (list or string), and the
+    ``executable=``, ``cwd=`` kwargs (IR-A4). ``env=`` is intentionally
+    excluded -- its values are typically system paths, and scanning them
+    generates too many false positives vs threat-model value.
+    """
+    argv: Any = args[0] if args else kwargs.get("args")
     candidates: list[str] = []
     if isinstance(argv, (list, tuple)):
-        for element in argv:
-            if isinstance(element, (bytes, bytearray)):
-                try:
-                    candidates.append(
-                        element.decode("utf-8", errors="replace")
-                    )
-                except Exception:
-                    candidates.append(str(element))
-            else:
-                candidates.append(str(element))
+        candidates.extend(_decode_candidate(e) for e in argv)
     elif isinstance(argv, (str, bytes, bytearray)):
-        if isinstance(argv, (bytes, bytearray)):
-            try:
-                candidates.append(argv.decode("utf-8", errors="replace"))
-            except Exception:
-                candidates.append(str(argv))
-        else:
-            candidates.append(argv)
-    needles = _forbidden_needles()
+        candidates.append(_decode_candidate(argv))
+    for kw in ("executable", "cwd"):
+        v = kwargs.get(kw)
+        if v is not None:
+            candidates.append(_decode_candidate(v))
+    return candidates
+
+
+def _argv_element_is_forbidden(posix: str) -> tuple[str, str] | None:
+    """Return ``(matched_name, evidence)`` if this argv element references a
+    forbidden persona path, else None.
+
+    Uses component-aware matching (IR-A2): ``personas/<name>`` followed by
+    end-of-string OR a non-word boundary counts as a hit. This catches
+    ``git -C personas/personal log`` (bare-dir), ``cat personas/personal/x``
+    (child-path), and ``--config=personas/personal`` (embedded) alike,
+    while ignoring ``personas/personality`` (different name).
+
+    Allow-list (IR-A5): any occurrence of an allow-listed prefix elsewhere
+    in the element does NOT short-circuit -- we only skip if the
+    forbidden hit is LEXICALLY CONTAINED WITHIN an allow-listed path
+    (e.g. ``tests/fixtures/personas/_template/`` via the template
+    allow-list). This closes the
+    ``--config=tests/fixtures/x:personas/personal/y`` bypass class.
+    """
+    for name in FORBIDDEN_PATH_NAMES:
+        pattern = re.compile(
+            rf"(?:^|[^A-Za-z0-9_]|/){re.escape('personas/' + name)}(?=$|[^A-Za-z0-9_])"
+        )
+        m = pattern.search(posix)
+        if not m:
+            continue
+        hit_start = m.start() + (1 if m.group().startswith(("/",)) or not m.group().startswith("personas") else 0)
+        # A hit is allow-listed ONLY if the substring from hit_start back
+        # to the start of an allow-listed prefix is purely path-component
+        # characters. Cheap approximation: does any allow-listed prefix
+        # occur as a prefix of posix AND extend through the hit position?
+        allowed = False
+        for prefix in ALLOWED_READ_PREFIXES:
+            prefix_posix = prefix.replace("\\", "/")
+            if posix.startswith(prefix_posix) and hit_start >= len(prefix_posix):
+                allowed = True
+                break
+        if allowed:
+            continue
+        return name, m.group()
+    return None
+
+
+def _patched_popen_init(self: subprocess.Popen, *args: Any, **kwargs: Any) -> Any:
+    candidates = _subprocess_candidates(args, kwargs)
     for element in candidates:
         posix_element = element.replace("\\", "/")
-        # Allow-list: a subprocess arg explicitly targeting fixtures is fine.
-        allowlisted = any(
-            prefix in posix_element for prefix in _allowed_prefixes()
-        )
-        if allowlisted:
-            continue
-        for needle in needles:
-            if needle in posix_element:
-                raise _PrivacyBoundaryViolation(
-                    "Privacy-boundary violation: subprocess argv element "
-                    f"{element!r} contained forbidden path prefix "
-                    f"{needle!r}. Public tests must use tests/fixtures/ "
-                    "instead. See docs/gotchas.md G6."
-                )
+        hit = _argv_element_is_forbidden(posix_element)
+        if hit is not None:
+            matched_name, evidence = hit
+            raise _PrivacyBoundaryViolation(
+                "Privacy-boundary violation: subprocess argv or kwargs "
+                f"referenced persona {matched_name!r} "
+                f"(matched pattern {evidence!r}). Public tests must use "
+                "tests/fixtures/ instead. See docs/gotchas.md G6."
+            )
     return _ORIGINALS["popen_init"](self, *args, **kwargs)
 
 
@@ -233,6 +324,13 @@ def _patched_popen_init(self: subprocess.Popen, *args: Any, **kwargs: Any) -> An
 
 
 def _install_patches() -> None:
+    # Idempotent: a second pytest_configure (xdist bootstrap, plugin
+    # re-registration, or a self-test that triggers pytest_configure
+    # manually) MUST NOT overwrite _ORIGINALS with the already-patched
+    # callables -- that would turn every subsequent I/O call into
+    # infinite recursion (IR-A1).
+    if _ORIGINALS:
+        return
     _ORIGINALS["path_open"] = pathlib.Path.open
     _ORIGINALS["path_read_text"] = pathlib.Path.read_text
     _ORIGINALS["path_read_bytes"] = pathlib.Path.read_bytes
@@ -273,13 +371,21 @@ def _self_probe() -> None:
     # a forbidden literal.
     canary_name = FORBIDDEN_PATH_NAMES[0] if FORBIDDEN_PATH_NAMES else "personal"
     canary = Path("personas") / canary_name / "privacy-guard-canary-nonexistent"
+    probe_outcome: str
     try:
         canary.read_text()
     except _PrivacyBoundaryViolation:
         return  # Guard is live -- correct outcome.
-    except BaseException:  # pragma: no cover -- indicates patch missed
-        pass
-    raise pytest.UsageError("Layer 2 privacy guard failed to install")
+    except (FileNotFoundError, OSError, PermissionError) as exc:
+        # Patches didn't fire but the real I/O path did -- guard is off.
+        probe_outcome = f"raised {type(exc).__name__} instead of _PrivacyBoundaryViolation"
+    except Exception as exc:  # narrower than BaseException (IR-A7)
+        probe_outcome = f"raised unexpected {type(exc).__name__}: {exc!r}"
+    else:
+        probe_outcome = "no exception -- guard patches are inert"
+    raise pytest.UsageError(
+        f"Layer 2 privacy guard failed to install (canary read {probe_outcome})"
+    )
 
 
 # ── pytest hooks ────────────────────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,49 @@
-"""Shared pytest fixtures.
+"""Shared pytest fixtures + two-layer privacy-boundary guard.
 
-All tests run against the real in-repo `roles/` and `personas/` directories.
-A fresh per-test working directory would break the submodule layout, so tests
-use the canonical project-root paths resolved from this file's location.
+Public tests run against the in-repo ``tests/fixtures/personas/`` root so the
+suite stays green without the private ``personas/<name>/`` submodules being
+initialized (spec: test-privacy-boundary / public-test-fixture-root).
+
+This conftest also implements **Layer 1** of the privacy-boundary guard:
+a ``pytest_collection_modifyitems`` hook that scans every collected test
+file (and every conftest under ``tests/``) for forbidden path substrings
+defined in ``tests/_privacy_guard_config.py``. **Layer 2** (runtime FS-I/O
+patching) lives in ``tests/_privacy_guard_plugin.py`` and is wired in via
+``pytest_plugins`` below. See that module and
+``openspec/changes/test-privacy-boundary/design.md`` D1+D9 for details.
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
 
+from tests._privacy_guard_config import (
+    FORBIDDEN_PATH_NAMES,
+    SCAN_EXCLUDED_DIRS,
+    SCAN_EXCLUDED_FILES,
+)
+
+# Layer 2 runtime guard -- registered as a plugin so its pytest_configure
+# hook runs before any test collects (so the self-probe fires before any
+# test body can read private content).
+pytest_plugins = ["tests._privacy_guard_plugin"]
+
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 ROLES_DIR = REPO_ROOT / "roles"
-PERSONAS_DIR = REPO_ROOT / "personas"
+# Public-test persona root: the in-repo fixture tree. Public tests MUST NOT
+# read from ``REPO_ROOT / "personas"`` (the real submodule mount) -- the
+# Layer 2 runtime guard will reject any such read.
+PERSONAS_DIR = REPO_ROOT / "tests" / "fixtures" / "personas"
+
+# Point every in-process PersonaRegistry (including the one the CLI builds
+# via `assistant -p personal`) at the fixture root for the duration of the
+# pytest session. Production callers with the env var unset keep their
+# existing default (Path("personas")).
+os.environ.setdefault("ASSISTANT_PERSONAS_DIR", str(PERSONAS_DIR))
 
 
 @pytest.fixture
@@ -29,3 +59,103 @@ def personas_dir() -> Path:
 @pytest.fixture
 def repo_root() -> Path:
     return REPO_ROOT
+
+
+# ── Layer 1: collection-time substring scan ────────────────────────────
+
+
+# Cache of already-scanned files keyed on POSIX repo-relative path, so
+# each file's source is read once per session even if multiple items
+# resolve to it.
+_SCANNED_FILES: set[str] = set()
+
+
+def _forbidden_substrings() -> tuple[str, ...]:
+    """Build needles dynamically from the deny-list config.
+
+    Keeps this conftest free of forbidden literals (so it doesn't self-trip
+    when Layer 1 scans itself) and auto-extends when a new persona name is
+    added to ``FORBIDDEN_PATH_NAMES``.
+    """
+    return tuple(f"personas/{name}/" for name in FORBIDDEN_PATH_NAMES)
+
+
+def _is_excluded(rel_posix: str) -> bool:
+    if rel_posix in SCAN_EXCLUDED_FILES:
+        return True
+    for d in SCAN_EXCLUDED_DIRS:
+        if rel_posix.startswith(d):
+            return True
+    return False
+
+
+def _scan_file(rel_posix: str, abs_path: Path) -> None:
+    """Scan one file for forbidden substrings; raise on violation.
+
+    Uses the saved original ``Path.read_text`` via the Layer 2 plugin's
+    stash if present (the plugin allow-lists our own scan; ``tests/`` is
+    not under ``personas/<forbidden>/`` so it isn't flagged anyway).
+    """
+    if rel_posix in _SCANNED_FILES:
+        return
+    _SCANNED_FILES.add(rel_posix)
+    try:
+        source = abs_path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, UnicodeDecodeError):
+        return  # non-readable or binary -- nothing to scan
+    for needle in _forbidden_substrings():
+        if needle in source:
+            raise pytest.UsageError(
+                f"Privacy-boundary violation: {rel_posix} contains "
+                f"forbidden path prefix {needle!r}. Public tests must use "
+                "tests/fixtures/ instead. Add the file to "
+                "tests/_privacy_guard_config.SCAN_EXCLUDED_FILES only if "
+                "it legitimately needs the substring as data (hygiene "
+                "tests). See docs/gotchas.md G6."
+            )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    """Layer 1: scan every collected test file + conftest for forbidden paths.
+
+    Runs once per collection. Scans each unique source file once (memoized
+    via ``_SCANNED_FILES``). On first violation, raises ``pytest.UsageError``
+    naming the file and matched deny-list entry, NOT echoing the file's
+    contents (spec: "Guard failure messages do not echo private payloads").
+    """
+    repo_root = REPO_ROOT.resolve()
+
+    # Collect unique test-file paths from items.
+    candidate_paths: set[Path] = set()
+    for item in items:
+        fs_path = getattr(item, "path", None)
+        if fs_path is None:
+            continue
+        try:
+            candidate_paths.add(Path(str(fs_path)).resolve())
+        except Exception:
+            continue
+
+    # Also scan every conftest.py under tests/ (D9: fixtures-via-conftest
+    # bypass closure). rglob via the original Path.rglob -- Layer 2 guard
+    # does not patch rglob, so this is safe.
+    tests_root = repo_root / "tests"
+    if tests_root.is_dir():
+        for conftest in tests_root.rglob("conftest.py"):
+            try:
+                candidate_paths.add(conftest.resolve())
+            except Exception:
+                continue
+
+    for abs_path in candidate_paths:
+        try:
+            rel = abs_path.relative_to(repo_root)
+        except ValueError:
+            continue  # outside repo -- not in scope
+        rel_posix = rel.as_posix()
+        if _is_excluded(rel_posix):
+            continue
+        _scan_file(rel_posix, abs_path)

--- a/tests/fixtures/personas/personal/prompt.md
+++ b/tests/fixtures/personas/personal/prompt.md
@@ -1,4 +1,12 @@
-## Personal Persona Context
+<!--
+  FIXTURE_PERSONA_SENTINEL_v1 (tests-only marker; not present in real submodule)
+
+  The sentinel below is asserted by tests/test_composition.py and
+  tests/test_persona_registry.py to prove end-to-end composition/loader
+  coverage without leaking any private-submodule content into public tests.
+  Do NOT rename or remove without updating those tests.
+-->
+## Personal Persona Context (FIXTURE_PERSONA_SENTINEL_v1)
 
 You are operating in Jan's **personal context**.
 

--- a/tests/fixtures/personas/personal/roles/researcher.yaml
+++ b/tests/fixtures/personas/personal/roles/researcher.yaml
@@ -1,5 +1,9 @@
+# FIXTURE_ROLE_SENTINEL_v1 (tests-only marker; not in real submodule).
+# Asserted by tests/test_role_registry.py to prove the role-override
+# prompt-append path is exercised against the fixture without leaking
+# private-submodule content into public tests.
 prompt_append: |
-  ### Personal Context Additions
+  ### Personal Context Additions (FIXTURE_ROLE_SENTINEL_v1)
   - Tone can be more exploratory and speculative
   - Include "things to try" and hands-on experiment suggestions
   - Connect findings to personal projects and learning goals

--- a/tests/test_ci_workflow_hygiene.py
+++ b/tests/test_ci_workflow_hygiene.py
@@ -1,0 +1,61 @@
+"""Regression guard: no GitHub workflow should reference private persona paths.
+
+After commit 76a313e's populate-personas step was removed (design D6), no
+CI workflow, action, or composite action should reference
+``personas/personal/`` or ``personas/work/`` at all. If a future PR adds
+such a reference, this test fails loudly at the same layer the rest of
+the privacy boundary relies on.
+
+Needles are constructed dynamically from ``FORBIDDEN_PATH_NAMES`` so this
+file's own source does not contain forbidden literals (Layer 1 self-trip
+avoidance, design D9 + Round 2 finding B-N4). This file is also on the
+Layer 1 exclusion list as belt-and-suspenders.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests._privacy_guard_config import FORBIDDEN_PATH_NAMES
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GITHUB_DIR = REPO_ROOT / ".github"
+
+
+def _workflow_files() -> list[Path]:
+    if not GITHUB_DIR.exists():
+        return []
+    return sorted(
+        p
+        for ext in ("yml", "yaml")
+        for glob in (f"workflows/*.{ext}", f"actions/**/*.{ext}")
+        for p in GITHUB_DIR.glob(glob)
+    )
+
+
+def _forbidden_needles() -> tuple[str, ...]:
+    return tuple(f"personas/{name}/" for name in FORBIDDEN_PATH_NAMES)
+
+
+@pytest.mark.parametrize("workflow_file", _workflow_files(), ids=lambda p: p.name)
+def test_workflow_has_no_forbidden_persona_reference(workflow_file: Path) -> None:
+    content = workflow_file.read_text()
+    needles = _forbidden_needles()
+    for needle in needles:
+        if needle in content:
+            raise AssertionError(
+                f"Workflow {workflow_file.relative_to(REPO_ROOT)} references "
+                f"a forbidden persona path ({needle!r}). After the populate"
+                f"-personas step removal (design D6), no workflow should "
+                f"read/write to the real submodule mount; use fixtures. "
+                f"See docs/gotchas.md G6."
+            )
+
+
+def test_at_least_one_workflow_scanned() -> None:
+    assert _workflow_files(), (
+        "Expected .github/workflows/*.yml to exist; test_workflow_has_no_"
+        "forbidden_persona_reference is silently skipping everything."
+    )

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -109,14 +109,27 @@ def test_always_plan_includes_planning_line() -> None:
     assert "plan" in out.lower()
 
 
-def test_composition_against_real_configs(
+def test_composition_against_fixture_configs(
     personas_dir: Path, roles_dir: Path
 ) -> None:
-    """Integration: composes against the real personal + researcher configs."""
+    """Integration: composes against the FIXTURE personal + researcher configs.
+
+    Replaces the removed ``test_composition_against_real_configs`` (which
+    asserted on strings sourced from the real private submodule). The
+    fixture files under the personal-persona fixture tree carry
+    intentional, tests-only sentinels (``FIXTURE_PERSONA_SENTINEL_v1`` in
+    prompt.md, ``FIXTURE_ROLE_SENTINEL_v1`` in roles/researcher.yaml) so
+    we can prove end-to-end composition coverage without coupling the
+    assertion to any private content.
+    """
     persona = PersonaRegistry(personas_dir).load("personal")
     role = RoleRegistry(roles_dir, personas_dir).load("researcher", persona)
     out = compose_system_prompt(persona, role)
-    assert "Personal Persona Context" in out
+    # Base + role presence (base-role strings are public, in roles/).
     assert "Role: Researcher" in out
     assert "**Persona**: Personal" in out
     assert "**Role**: Researcher" in out
+    # Persona-layer fixture sentinel (sourced from fixture prompt.md).
+    assert "FIXTURE_PERSONA_SENTINEL_v1" in out
+    # Role-layer fixture sentinel (sourced from fixture role override).
+    assert "FIXTURE_ROLE_SENTINEL_v1" in out

--- a/tests/test_env_var_contract.py
+++ b/tests/test_env_var_contract.py
@@ -1,0 +1,94 @@
+"""Unit tests for the ASSISTANT_PERSONAS_DIR env-var contract.
+
+Locks in the precedence rule:
+
+    explicit constructor arg  >  env var  >  Path("personas") default
+
+The env var was added as a scope expansion during implementation of
+OpenSpec change ``test-privacy-boundary`` (see session-log.md ->
+Implementation phase, decision 1). Without these tests, a future
+refactor could silently break the only mechanism by which in-process
+CLI tests honor the privacy-boundary repoint.
+
+Covers Review finding IR-C2.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from assistant.core.persona import PersonaRegistry
+from assistant.core.role import RoleRegistry
+
+# ── PersonaRegistry ────────────────────────────────────────────────────
+
+
+def test_persona_registry_no_args_reads_env_var(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """PersonaRegistry() with no argument uses ASSISTANT_PERSONAS_DIR when set."""
+    custom = tmp_path / "custom-personas"
+    custom.mkdir()
+    monkeypatch.setenv("ASSISTANT_PERSONAS_DIR", str(custom))
+    reg = PersonaRegistry()
+    assert reg.personas_dir == custom
+
+
+def test_persona_registry_explicit_arg_overrides_env_var(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """PersonaRegistry(path) ignores ASSISTANT_PERSONAS_DIR -- explicit wins."""
+    env_path = tmp_path / "env-personas"
+    explicit = tmp_path / "explicit-personas"
+    env_path.mkdir()
+    explicit.mkdir()
+    monkeypatch.setenv("ASSISTANT_PERSONAS_DIR", str(env_path))
+    reg = PersonaRegistry(explicit)
+    assert reg.personas_dir == explicit
+
+
+def test_persona_registry_no_args_no_env_uses_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With env var unset and no arg, PersonaRegistry defaults to Path('personas')."""
+    monkeypatch.delenv("ASSISTANT_PERSONAS_DIR", raising=False)
+    reg = PersonaRegistry()
+    assert reg.personas_dir == Path("personas")
+
+
+# ── RoleRegistry ───────────────────────────────────────────────────────
+
+
+def test_role_registry_no_args_reads_env_var(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """RoleRegistry() with no personas_dir argument uses ASSISTANT_PERSONAS_DIR."""
+    custom = tmp_path / "custom-personas"
+    custom.mkdir()
+    monkeypatch.setenv("ASSISTANT_PERSONAS_DIR", str(custom))
+    reg = RoleRegistry()
+    assert reg.personas_dir == custom
+
+
+def test_role_registry_explicit_personas_dir_overrides_env_var(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """RoleRegistry(personas_dir=explicit) ignores env var."""
+    env_path = tmp_path / "env-personas"
+    explicit = tmp_path / "explicit-personas"
+    env_path.mkdir()
+    explicit.mkdir()
+    monkeypatch.setenv("ASSISTANT_PERSONAS_DIR", str(env_path))
+    reg = RoleRegistry(personas_dir=explicit)
+    assert reg.personas_dir == explicit
+
+
+def test_role_registry_no_args_no_env_uses_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With env var unset and no arg, RoleRegistry defaults to Path('personas')."""
+    monkeypatch.delenv("ASSISTANT_PERSONAS_DIR", raising=False)
+    reg = RoleRegistry()
+    assert reg.personas_dir == Path("personas")

--- a/tests/test_persona_registry.py
+++ b/tests/test_persona_registry.py
@@ -80,7 +80,9 @@ def test_loaded_result_is_cached(personas_dir: Path) -> None:
 def test_prompt_md_is_loaded(personas_dir: Path) -> None:
     registry = PersonaRegistry(personas_dir)
     cfg = registry.load("personal")
-    assert "Personal Persona Context" in cfg.prompt_augmentation
+    # Fixture-defined sentinel in the fixture's prompt.md -- proves
+    # prompt.md was loaded without asserting on private-submodule content.
+    assert "FIXTURE_PERSONA_SENTINEL_v1" in cfg.prompt_augmentation
 
 
 def test_memory_md_is_optional(tmp_path: Path) -> None:

--- a/tests/test_privacy_guard.py
+++ b/tests/test_privacy_guard.py
@@ -1,0 +1,298 @@
+"""Tests for the two-layer privacy-boundary guard.
+
+Each test builds a synthetic pytest-runnable tree under ``tmp_path`` and
+invokes ``python -m pytest`` against it as a subprocess, so the real
+repo's conftest + Layer 2 plugin run from a fresh pytest session inside
+the tmp tree. The subprocess approach sidesteps ``pytester``'s plugin-
+registration requirement (Round 1 finding I6).
+
+All forbidden-substring literals in this file are **constructed
+dynamically** from ``FORBIDDEN_PATH_NAMES`` (per D9 / Round 2 B-N4), so
+this module itself never embeds a literal ``personas/<forbidden>/``
+string in its source -- Layer 1 would otherwise reject it at collection.
+
+The synthetic test trees copy the **real** conftest and plugin module
+sources into tmp_path as a standalone ``tests/`` package so the guard is
+actually live inside the subprocess session.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from tests._privacy_guard_config import FORBIDDEN_PATH_NAMES
+
+# Build the forbidden path fragments dynamically. After this point the
+# file may contain these substrings at RUNTIME but NOT as source literals.
+FORBIDDEN_NAME = FORBIDDEN_PATH_NAMES[0]  # e.g. "personal"
+FORBIDDEN_PREFIX = f"personas/{FORBIDDEN_NAME}/"
+FORBIDDEN_DIR_SEGMENTS = ("personas", FORBIDDEN_NAME)  # for Path-joining
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_CONFTEST = REPO_ROOT / "tests" / "conftest.py"
+SRC_PLUGIN = REPO_ROOT / "tests" / "_privacy_guard_plugin.py"
+SRC_CONFIG = REPO_ROOT / "tests" / "_privacy_guard_config.py"
+
+
+def _scaffold_synthetic_tree(tmp_path: Path) -> Path:
+    """Create a tmp pytest tree with the real guard wired in.
+
+    Layout:
+        tmp_path/
+          pyproject.toml       # minimal, no [tool.pytest.ini_options]
+          tests/
+            __init__.py
+            conftest.py              <- copied from repo
+            _privacy_guard_plugin.py <- copied from repo
+            _privacy_guard_config.py <- copied from repo
+    Returns the ``tmp_path`` root.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname = 'synthetic-guard-test'\nversion = '0'\n"
+    )
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "__init__.py").write_text("")
+    (tests / "conftest.py").write_text(SRC_CONFTEST.read_text())
+    (tests / "_privacy_guard_plugin.py").write_text(SRC_PLUGIN.read_text())
+    (tests / "_privacy_guard_config.py").write_text(SRC_CONFIG.read_text())
+    return tmp_path
+
+
+def _run_pytest(tmp_path: Path, *extra: str) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    # Make tmp_path importable so ``tests._privacy_guard_plugin`` resolves.
+    env["PYTHONPATH"] = str(tmp_path) + os.pathsep + env.get("PYTHONPATH", "")
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", "-p", "no:cacheprovider",
+         str(tmp_path / "tests"), *extra],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(tmp_path),
+    )
+
+
+# ── Layer 1 ────────────────────────────────────────────────────────────
+
+
+def test_layer1_rejects_literal_forbidden_substring(tmp_path: Path) -> None:
+    root = _scaffold_synthetic_tree(tmp_path)
+    # Write a test file containing the forbidden literal in its SOURCE.
+    offender = root / "tests" / "test_offender.py"
+    offender.write_text(
+        textwrap.dedent(
+            f"""
+            # This file intentionally contains a forbidden substring.
+            FORBIDDEN = "{FORBIDDEN_PREFIX}persona.yaml"
+
+            def test_ok() -> None:
+                assert FORBIDDEN
+            """
+        )
+    )
+    result = _run_pytest(root)
+    assert result.returncode != 0, (result.stdout, result.stderr)
+    combined = result.stdout + result.stderr
+    assert "Privacy-boundary violation" in combined
+    assert FORBIDDEN_PREFIX in combined
+    assert "test_offender.py" in combined
+
+
+def test_layer1_allows_fixture_and_template_references(tmp_path: Path) -> None:
+    root = _scaffold_synthetic_tree(tmp_path)
+    ok = root / "tests" / "test_allowed.py"
+    ok.write_text(
+        textwrap.dedent(
+            """
+            # Fixture + template references are NOT forbidden.
+            FIXTURE = "tests/fixtures/personas/whatever/x.yaml"
+            TEMPLATE = "personas/_template/role.yaml"
+
+            def test_ok() -> None:
+                assert FIXTURE and TEMPLATE
+            """
+        )
+    )
+    result = _run_pytest(root)
+    assert result.returncode == 0, (result.stdout, result.stderr)
+
+
+def test_layer1_excludes_its_own_implementation_files(tmp_path: Path) -> None:
+    """The config + plugin files contain forbidden substrings as data --
+    Layer 1 must NOT flag them."""
+    root = _scaffold_synthetic_tree(tmp_path)
+    # Add a placeholder test so pytest has something to collect.
+    (root / "tests" / "test_dummy.py").write_text(
+        "def test_ok() -> None:\n    assert True\n"
+    )
+    result = _run_pytest(root)
+    assert result.returncode == 0, (result.stdout, result.stderr)
+
+
+# ── Layer 2 ────────────────────────────────────────────────────────────
+
+
+def test_layer2_rejects_path_read_text_on_forbidden(tmp_path: Path) -> None:
+    root = _scaffold_synthetic_tree(tmp_path)
+    offender = root / "tests" / "test_runtime_read.py"
+    # Build the forbidden path at RUNTIME via Path-joining so the source
+    # of this synthetic test contains no forbidden literal.
+    offender.write_text(
+        textwrap.dedent(
+            f"""
+            from pathlib import Path
+
+            def test_runtime_read() -> None:
+                target = Path({FORBIDDEN_DIR_SEGMENTS[0]!r}) / {FORBIDDEN_DIR_SEGMENTS[1]!r} / "persona.yaml"
+                target.read_text()
+            """
+        )
+    )
+    result = _run_pytest(root)
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "Privacy-boundary violation" in combined
+
+
+def test_layer2_rejects_os_open_on_forbidden(tmp_path: Path) -> None:
+    root = _scaffold_synthetic_tree(tmp_path)
+    offender = root / "tests" / "test_os_open.py"
+    offender.write_text(
+        textwrap.dedent(
+            f"""
+            import os
+
+            def test_os_open() -> None:
+                path = "{FORBIDDEN_DIR_SEGMENTS[0]}" + "/" + "{FORBIDDEN_DIR_SEGMENTS[1]}" + "/persona.yaml"
+                os.open(path, os.O_RDONLY)
+            """
+        )
+    )
+    result = _run_pytest(root)
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "Privacy-boundary violation" in combined
+
+
+def test_layer2_rejects_subprocess_argv_with_forbidden(tmp_path: Path) -> None:
+    root = _scaffold_synthetic_tree(tmp_path)
+    offender = root / "tests" / "test_subproc.py"
+    offender.write_text(
+        textwrap.dedent(
+            f"""
+            import subprocess
+
+            def test_subproc() -> None:
+                arg = "{FORBIDDEN_DIR_SEGMENTS[0]}" + "/" + "{FORBIDDEN_DIR_SEGMENTS[1]}" + "/persona.yaml"
+                subprocess.run(["cat", arg])
+            """
+        )
+    )
+    result = _run_pytest(root)
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "Privacy-boundary violation" in combined
+
+
+def test_layer2_allows_reads_under_fixtures(tmp_path: Path) -> None:
+    root = _scaffold_synthetic_tree(tmp_path)
+    # Create a fixture file to read from.
+    fixtures = root / "tests" / "fixtures" / "personas" / "synthetic"
+    fixtures.mkdir(parents=True)
+    (fixtures / "persona.yaml").write_text("name: synthetic\n")
+    ok = root / "tests" / "test_fixture_read.py"
+    ok.write_text(
+        textwrap.dedent(
+            """
+            from pathlib import Path
+
+            def test_fixture_read() -> None:
+                here = Path(__file__).resolve().parent
+                target = here / "fixtures" / "personas" / "synthetic" / "persona.yaml"
+                assert "synthetic" in target.read_text()
+            """
+        )
+    )
+    result = _run_pytest(root)
+    assert result.returncode == 0, (result.stdout, result.stderr)
+
+
+def test_layer2_rejects_constructed_path_join(tmp_path: Path) -> None:
+    """Covers the ``Path('personas') / name / 'x.yaml'`` idiom that
+    substring-only checks miss."""
+    root = _scaffold_synthetic_tree(tmp_path)
+    offender = root / "tests" / "test_constructed.py"
+    offender.write_text(
+        textwrap.dedent(
+            f"""
+            from pathlib import Path
+
+            def test_constructed() -> None:
+                # Name is a variable, not a literal in the source.
+                name = {FORBIDDEN_DIR_SEGMENTS[1]!r}
+                p = Path("personas") / name / "x.yaml"
+                p.read_text()
+            """
+        )
+    )
+    result = _run_pytest(root)
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "Privacy-boundary violation" in combined
+
+
+def test_layer2_self_probe_fires_when_install_is_noop(tmp_path: Path) -> None:
+    """If the plugin's install step is short-circuited, the self-probe
+    must fail the session via pytest.UsageError."""
+    root = _scaffold_synthetic_tree(tmp_path)
+    # Overwrite the plugin with a broken install that no-ops. Reuses the
+    # public API so the self-probe path is still exercised.
+    broken_plugin = textwrap.dedent(
+        '''
+        """Broken plugin: install is no-op to simulate CPython blocking
+        Python-level rebinding of a C-slot method. Self-probe must fire."""
+        from __future__ import annotations
+        from pathlib import Path
+        import pytest
+        from tests._privacy_guard_config import FORBIDDEN_PATH_NAMES
+
+
+        class _PrivacyBoundaryViolation(pytest.UsageError):
+            pass
+
+
+        def _install_patches() -> None:
+            return  # no-op to simulate failure
+
+
+        def _self_probe() -> None:
+            canary_name = FORBIDDEN_PATH_NAMES[0]
+            canary = Path("personas") / canary_name / "privacy-guard-canary-nonexistent"
+            try:
+                canary.read_text()
+            except _PrivacyBoundaryViolation:
+                return
+            except BaseException:
+                pass
+            raise pytest.UsageError("Layer 2 privacy guard failed to install")
+
+
+        def pytest_configure(config: pytest.Config) -> None:
+            _install_patches()
+            _self_probe()
+        '''
+    )
+    (root / "tests" / "_privacy_guard_plugin.py").write_text(broken_plugin)
+    # Add a harmless test so collection happens.
+    (root / "tests" / "test_harmless.py").write_text(
+        "def test_ok() -> None:\n    assert True\n"
+    )
+    result = _run_pytest(root)
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "Layer 2 privacy guard failed to install" in combined

--- a/tests/test_privacy_guard.py
+++ b/tests/test_privacy_guard.py
@@ -296,3 +296,211 @@ def test_layer2_self_probe_fires_when_install_is_noop(tmp_path: Path) -> None:
     assert result.returncode != 0
     combined = result.stdout + result.stderr
     assert "Layer 2 privacy guard failed to install" in combined
+
+
+# ── Additional Layer 2 coverage (IMPL_REVIEW IR-A6) ────────────────────
+
+
+def test_layer2_rejects_builtins_open_on_forbidden(tmp_path: Path) -> None:
+    root = _scaffold_synthetic_tree(tmp_path)
+    offender = root / "tests" / "test_builtins_open.py"
+    offender.write_text(
+        textwrap.dedent(
+            f"""
+            def test_builtins_open() -> None:
+                path = "{FORBIDDEN_DIR_SEGMENTS[0]}" + "/" + "{FORBIDDEN_DIR_SEGMENTS[1]}" + "/persona.yaml"
+                open(path, "r")
+            """
+        )
+    )
+    result = _run_pytest(root)
+    assert result.returncode != 0
+    assert "Privacy-boundary violation" in (result.stdout + result.stderr)
+
+
+def test_layer2_rejects_path_open_on_forbidden(tmp_path: Path) -> None:
+    root = _scaffold_synthetic_tree(tmp_path)
+    offender = root / "tests" / "test_path_open.py"
+    offender.write_text(
+        textwrap.dedent(
+            f"""
+            from pathlib import Path
+
+            def test_path_open() -> None:
+                p = Path({FORBIDDEN_DIR_SEGMENTS[0]!r}) / {FORBIDDEN_DIR_SEGMENTS[1]!r} / "persona.yaml"
+                p.open("r")
+            """
+        )
+    )
+    result = _run_pytest(root)
+    assert result.returncode != 0
+    assert "Privacy-boundary violation" in (result.stdout + result.stderr)
+
+
+def test_layer2_rejects_path_read_bytes_on_forbidden(tmp_path: Path) -> None:
+    root = _scaffold_synthetic_tree(tmp_path)
+    offender = root / "tests" / "test_read_bytes.py"
+    offender.write_text(
+        textwrap.dedent(
+            f"""
+            from pathlib import Path
+
+            def test_read_bytes() -> None:
+                p = Path({FORBIDDEN_DIR_SEGMENTS[0]!r}) / {FORBIDDEN_DIR_SEGMENTS[1]!r} / "persona.yaml"
+                p.read_bytes()
+            """
+        )
+    )
+    result = _run_pytest(root)
+    assert result.returncode != 0
+    assert "Privacy-boundary violation" in (result.stdout + result.stderr)
+
+
+# ── Additional bypass coverage (IMPL_REVIEW IR-A2, IR-A3, IR-A4) ──────
+
+
+def test_layer2_rejects_git_C_style_bare_directory_argv(tmp_path: Path) -> None:
+    """IR-A2: ``git -C personas/personal log`` — the directory argument
+    is the bare ``personas/<name>`` (no trailing slash). Substring match
+    on ``personas/<name>/`` would miss; component-aware match catches it."""
+    root = _scaffold_synthetic_tree(tmp_path)
+    offender = root / "tests" / "test_git_c.py"
+    offender.write_text(
+        textwrap.dedent(
+            f"""
+            import subprocess
+
+            def test_git_c() -> None:
+                bare_dir = "{FORBIDDEN_DIR_SEGMENTS[0]}" + "/" + "{FORBIDDEN_DIR_SEGMENTS[1]}"
+                subprocess.run(["git", "-C", bare_dir, "log"], check=False)
+            """
+        )
+    )
+    result = _run_pytest(root)
+    assert result.returncode != 0
+    assert "Privacy-boundary violation" in (result.stdout + result.stderr)
+
+
+def test_layer2_rejects_subprocess_executable_kwarg(tmp_path: Path) -> None:
+    """IR-A4: executable= kwarg with a forbidden path must be caught."""
+    root = _scaffold_synthetic_tree(tmp_path)
+    offender = root / "tests" / "test_exec_kwarg.py"
+    offender.write_text(
+        textwrap.dedent(
+            f"""
+            import subprocess
+
+            def test_exec_kwarg() -> None:
+                exe = "{FORBIDDEN_DIR_SEGMENTS[0]}" + "/" + "{FORBIDDEN_DIR_SEGMENTS[1]}" + "/secret.sh"
+                subprocess.Popen(args=["--help"], executable=exe)
+            """
+        )
+    )
+    result = _run_pytest(root)
+    assert result.returncode != 0
+    assert "Privacy-boundary violation" in (result.stdout + result.stderr)
+
+
+def test_layer2_rejects_subprocess_cwd_kwarg(tmp_path: Path) -> None:
+    """IR-A4: cwd= kwarg targeting a forbidden directory must be caught."""
+    root = _scaffold_synthetic_tree(tmp_path)
+    offender = root / "tests" / "test_cwd_kwarg.py"
+    offender.write_text(
+        textwrap.dedent(
+            f"""
+            import subprocess
+
+            def test_cwd_kwarg() -> None:
+                target = "{FORBIDDEN_DIR_SEGMENTS[0]}" + "/" + "{FORBIDDEN_DIR_SEGMENTS[1]}"
+                subprocess.run(["ls"], cwd=target, check=False)
+            """
+        )
+    )
+    result = _run_pytest(root)
+    assert result.returncode != 0
+    assert "Privacy-boundary violation" in (result.stdout + result.stderr)
+
+
+def test_layer2_rejects_symlink_escape_from_fixtures(tmp_path: Path) -> None:
+    """IR-A3: a symlink under tests/fixtures/ (allow-listed by prefix)
+    pointing into personas/<forbidden>/ must still be rejected on the
+    actual read attempt (resolve-pass catches the escape).
+
+    Setup happens INSIDE the subprocess session (via a conftest fixture
+    written dynamically) because the outer pytest session's Layer 2
+    guard would otherwise reject the test's own mkdir of the forbidden
+    tree -- the outer guard matches the literal substring
+    ``personas/<forbidden>`` in any absolute path.
+    """
+    root = _scaffold_synthetic_tree(tmp_path)
+    # A conftest fixture in the synthetic tree performs the forbidden-
+    # tree mkdir + symlink BEFORE any test collects; the subprocess's
+    # own Layer 2 plugin self-probe fires after pytest_configure but
+    # before the fixture runs, so setup uses os.makedirs / os.symlink
+    # via direct-install circumvention -- wait, the plugin patches
+    # os.open too. Use pytest's conftest-level pytest_configure hook
+    # to set up BEFORE the plugin installs its patches.
+    (root / "tests" / "conftest.py").write_text(
+        SRC_CONFTEST.read_text()
+        + textwrap.dedent(
+            f"""
+
+            # Test-setup hook that runs before the Layer 2 plugin patches
+            # (same conftest module is loaded before pytest_plugins list).
+            def _build_symlink_tree():
+                from pathlib import Path
+                repo = Path(__file__).resolve().parents[1]
+                tgt = repo / {FORBIDDEN_DIR_SEGMENTS[0]!r} / {FORBIDDEN_DIR_SEGMENTS[1]!r}
+                tgt.mkdir(parents=True, exist_ok=True)
+                (tgt / "secret.yaml").write_text("private: yes\\n")
+                fixtures_root = repo / "tests" / "fixtures"
+                fixtures_root.mkdir(parents=True, exist_ok=True)
+                sneaky = fixtures_root / "sneaky"
+                if not sneaky.exists():
+                    sneaky.symlink_to(tgt, target_is_directory=True)
+
+
+            _build_symlink_tree()
+            """
+        )
+    )
+    offender = root / "tests" / "test_sneaky.py"
+    offender.write_text(
+        textwrap.dedent(
+            """
+            from pathlib import Path
+
+            def test_sneaky() -> None:
+                here = Path(__file__).resolve().parent
+                sneaky = here / "fixtures" / "sneaky" / "secret.yaml"
+                sneaky.read_text()  # symlink resolves to forbidden dir
+            """
+        )
+    )
+    result = _run_pytest(root)
+    assert result.returncode != 0, (result.stdout, result.stderr)
+    assert "Privacy-boundary violation" in (result.stdout + result.stderr)
+
+
+# ── Idempotent install (IR-A1) ────────────────────────────────────────
+
+
+def test_install_patches_is_idempotent() -> None:
+    """Calling _install_patches twice must not overwrite _ORIGINALS with
+    already-patched callables (which would cause infinite recursion on
+    the first real I/O call)."""
+    import tests._privacy_guard_plugin as plugin
+
+    # Snapshot current originals (they were installed at pytest_configure
+    # time when this session started).
+    before = dict(plugin._ORIGINALS)
+    # Second install must be a no-op.
+    plugin._install_patches()
+    after = dict(plugin._ORIGINALS)
+    assert before == after, (
+        "Second _install_patches call mutated _ORIGINALS -- would cause "
+        "infinite recursion on any I/O call (IR-A1)."
+    )
+    # Confirm the patched callables are not stored as originals.
+    assert plugin._ORIGINALS["path_open"] is not plugin._patched_path_open
+    assert plugin._ORIGINALS["path_read_text"] is not plugin._patched_path_read_text

--- a/tests/test_role_registry.py
+++ b/tests/test_role_registry.py
@@ -52,7 +52,8 @@ def test_disabled_role_is_filtered_out(
 def test_base_role_loads_without_overrides(
     roles_dir: Path, personas_dir: Path
 ) -> None:
-    # planner has no override in personas/personal/roles/ → base values only
+    # planner has no override in the persona's role-overrides dir → base
+    # values only
     persona = PersonaRegistry(personas_dir).load("personal")
     role = RoleRegistry(roles_dir, personas_dir).load("planner", persona)
     assert "content_analyzer:knowledge_graph" in role.preferred_tools
@@ -64,9 +65,12 @@ def test_prompt_append_extends_base_prompt(
     persona = PersonaRegistry(personas_dir).load("personal")
     role = RoleRegistry(roles_dir, personas_dir).load("researcher", persona)
     assert "Role: Researcher" in role.prompt  # base content present
-    assert "Personal Context Additions" in role.prompt  # override appended
+    # Fixture-defined sentinel in the fixture's researcher role-override
+    # yaml prompt_append -- proves override was appended without asserting
+    # on private-submodule content.
+    assert "FIXTURE_ROLE_SENTINEL_v1" in role.prompt
     assert role.prompt.index("Role: Researcher") < role.prompt.index(
-        "Personal Context Additions"
+        "FIXTURE_ROLE_SENTINEL_v1"
     )
 
 

--- a/tests/test_workspace_hygiene.py
+++ b/tests/test_workspace_hygiene.py
@@ -1,0 +1,59 @@
+"""Regression guard: the parent pyproject must not draw submodules into a uv workspace.
+
+Design D4 relies on the submodule's own ``[tool.uv]`` declaration to keep
+``uv run pytest`` inside the submodule from reusing the parent venv. But
+workspace *membership* is declared by the root, not the member — if the
+parent ever adds ``[tool.uv.workspace] members = ['personas/*']`` for dev
+ergonomics, the submodule's ``workspace.members = []`` cannot veto
+inclusion (Round 2 finding B-N6). This test asserts no such inclusion
+exists so the self-containment invariant stays load-bearing.
+
+Needles for the forbidden members are constructed dynamically from
+``FORBIDDEN_PATH_NAMES`` (same pattern as ``test_ci_workflow_hygiene``),
+so Layer 1's substring scan does not self-trip. This file is also in
+the Layer 1 exclusion list.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from tests._privacy_guard_config import FORBIDDEN_PATH_NAMES
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PARENT_PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+
+def _load_parent_pyproject() -> dict:
+    return tomllib.loads(PARENT_PYPROJECT.read_text())
+
+
+def _matches_forbidden_submodule(member_glob: str) -> str | None:
+    """Return the forbidden-name the glob expands to, or None."""
+    for name in FORBIDDEN_PATH_NAMES:
+        target = f"personas/{name}"
+        if member_glob == target or member_glob == f"{target}/":
+            return name
+        if member_glob.startswith("personas/") and member_glob.endswith(("*", "**")):
+            return name
+    return None
+
+
+def test_parent_pyproject_does_not_include_submodule_in_uv_workspace() -> None:
+    config = _load_parent_pyproject()
+    uv_workspace = config.get("tool", {}).get("uv", {}).get("workspace")
+    if uv_workspace is None:
+        return
+
+    members = uv_workspace.get("members", [])
+    for member in members:
+        forbidden = _matches_forbidden_submodule(member)
+        if forbidden is not None:
+            raise AssertionError(
+                f"Parent pyproject.toml declares workspace member {member!r} "
+                f"that draws the private submodule personas/{forbidden}/ "
+                f"into the parent venv. This defeats the self-containment "
+                f"invariant (design D4 / Round-2 finding B-N6). Remove the "
+                f"glob or exclude personas/ from the members list."
+            )


### PR DESCRIPTION
## Summary

Prevents private persona data (from the `personas/personal/` git submodule) from leaking into the public test suite. Public tests now read only from `tests/fixtures/personas/`, a two-layer pytest privacy guard enforces this at collection time (substring scan) and runtime (FS-I/O monkey-patching of 6 entry points), and persona-specific integration tests live inside the submodule's own self-contained `tests/` suite.

## What changed

**Public repo:**
- `tests/conftest.py`: `personas_dir` fixture repointed to `tests/fixtures/personas/`; Layer 1 collection-time guard (substring scan over test files + conftest); sets `ASSISTANT_PERSONAS_DIR` so in-process CLI tests honor the repoint without a new CLI flag.
- `tests/_privacy_guard_config.py`: single source of truth for `FORBIDDEN_PATH_NAMES = ("personal", "work")`, `ALLOWED_READ_PREFIXES`, exclusion list.
- `tests/_privacy_guard_plugin.py`: Layer 2 runtime guard — patches `pathlib.Path.open`/`read_text`/`read_bytes`, `builtins.open`, `os.open`, `subprocess.Popen.__init__`. Plugin self-probe at `pytest_configure` fires if patches silently fail to install. Component-aware argv matching catches `git -C personas/personal log` and `--config=.../personas/personal/...` bypasses; symlink-resolve pass catches `tests/fixtures/sneaky -> ../../personas/personal`.
- `tests/test_privacy_guard.py` (17 tests), `tests/test_env_var_contract.py` (6 tests), `tests/test_ci_workflow_hygiene.py` + `tests/test_workspace_hygiene.py`: regression guards against workflow-file leakage and future uv-workspace inclusion of the submodule.
- `src/assistant/core/persona.py` + `role.py`: `PersonaRegistry()` and `RoleRegistry()` honor `ASSISTANT_PERSONAS_DIR` when no explicit arg is supplied. Backward-compat preserved (unset env → `Path("personas")` default). Precedence (`explicit arg > env var > default`) locked by unit tests.
- `.github/workflows/ci.yml`: removed the \"populate personas/personal from test fixture\" step from commit 76a313e; `ASSISTANT_PERSONAS_DIR` set at job env level for defense in depth.
- `scripts/`: three helper scripts — `verify-public-tests-standalone.sh` (`git submodule deinit` + pytest + trap-protected restore), `verify-submodule-standalone.sh` (fresh `/tmp/spb-venv` + submodule-rooted pytest), `push-with-submodule.sh` (atomic dual-commit wrapper with exit-code 47 reserved for genuine dangling-SHA cases).
- `docs/gotchas.md`: G6 (private-content leakage, two-layer guard, `ASSISTANT_PERSONAS_DIR` contract) + G7 (`ALLOW_STANDALONE_SUBMODULE_SKIP` opt-in).
- `CLAUDE.md` Conventions: records the fixture-only + self-contained-submodule + two-layer-guard rule.

**Submodule (`agentic-assistant-config-personal` @ `openspec/test-privacy-boundary` — SHA `a82d7f8`):**
- `personas/personal/pyproject.toml`: pytest + pyyaml dev-deps, `[tool.uv] package = false`, empty `workspace.members` (prevents uv from reusing parent venv).
- `personas/personal/tests/{conftest.py, test_persona_yaml.py, test_role_overrides.py, test_no_assistant_import.py}`: self-contained YAML shape + role-override + no-assistant-import validation. Zero imports from `assistant.*`. Fresh-venv standalone proof via `scripts/verify-submodule-standalone.sh` asserts `importlib.import_module(\"assistant.core.persona\")` raises ImportError.

## Evidence trail

| Phase | Reviewers | Findings | Fix commit |
|---|---|---|---|
| PLAN_REVIEW Round 1 | 3 parallel | 27 (7B/13M/7m) | `917056d` |
| PLAN_REVIEW Round 2 | 2 parallel (verifier + adversarial) | 10 new (1B/7M/2m) | `09b5c02` |
| IMPLEMENT | 3 parallel subagents + main | — | `a82d7f8` (submodule) + `03724f8` (parent) |
| IMPL_REVIEW Round 1 | 3 parallel | 25 (4B/9M/12m) | `c24c158` |

All BLOCKING+MAJOR findings from every round resolved inline. Remaining MINOR findings deferred to follow-up or `/cleanup-feature` (details in `openspec/changes/test-privacy-boundary/session-log.md`).

## Known acknowledged limitations (design R2)

Layer 2 does NOT cover (accepted — outside the Copilot-accidental threat model):
- `mmap.mmap` on an already-opened fd
- `ctypes`-based I/O bypassing the stdlib
- `os.system` on Windows (dispatches via `cmd.exe`, not `subprocess.Popen`)
- Deliberately-split subprocess argv reconstructed at `execve` time

Layer 1 substring scan + path-based enforcement remains the closure for these cases.

## Verification

- `uv run pytest tests/`: **126 passed** (100 pre-existing + 17 privacy-guard + 6 env-var contract + 2 workflow-hygiene + 1 workspace-hygiene).
- `uv run mypy src tests`: **Success, no issues found in 38 source files**.
- `uv run ruff check .`: **All checks passed**.
- `bash scripts/verify-public-tests-standalone.sh`: **126 passed** with `personas/personal` deinit'd (proves goal G1 — public suite runs without the private submodule).
- `bash scripts/verify-submodule-standalone.sh`: **9 passed** in fresh `/tmp/spb-venv` with only pytest+pyyaml installed (proves goal G3 — submodule suite is self-contained; `assistant.core.persona` import raises ImportError as required).
- `openspec validate test-privacy-boundary --strict`: passes.

## Test plan

- [ ] Review the spec delta (5 requirements, 14 scenarios) and design (9 decisions, 4 risks) under `openspec/changes/test-privacy-boundary/`
- [ ] Review Layer 2 plugin code — `tests/_privacy_guard_plugin.py` (the core novel code)
- [ ] Verify CI passes on this PR (removed populate step; env var set at job level)
- [ ] Inspect submodule commit at `a82d7f8` on `agentic-assistant-config-personal:openspec/test-privacy-boundary` if reviewing submodule-side changes
- [ ] Spot-check that `uv run pytest` in a clean checkout without the submodule initialized still produces green

## Next step

After merge:
```
/cleanup-feature test-privacy-boundary
```
Archives the OpenSpec change, syncs the spec delta into `openspec/specs/`, and handles the submodule SHA bump on main.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — autopilot flow

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>