### PR TITLE
Integrate perplexity feedback into roadmap v2

### DIFF
--- a/openspec/changes/roadmap-v2-perplexity-integration/contracts/README.md
+++ b/openspec/changes/roadmap-v2-perplexity-integration/contracts/README.md
@@ -1,0 +1,17 @@
+# Contracts — roadmap-v2-perplexity-integration
+
+No contracts applicable to this change.
+
+## Sub-types evaluated
+
+- **OpenAPI contracts**: not applicable — this change introduces no API
+  endpoints; all per-phase APIs (e.g., P6 `/a2a/v1/message:stream`) are
+  defined by their own downstream proposals.
+- **Database contracts**: not applicable — no schema changes in this
+  proposal. Per-persona schema is the scope of P2 memory-architecture.
+- **Event contracts**: not applicable — no events are emitted or
+  consumed.
+- **Type-generation stubs**: not applicable — no generated code.
+
+Per `/plan-feature` Step 7, a `contracts/` directory containing only
+this `README.md` signals "no contracts applicable" to consuming skills.

--- a/openspec/changes/roadmap-v2-perplexity-integration/design.md
+++ b/openspec/changes/roadmap-v2-perplexity-integration/design.md
@@ -1,0 +1,116 @@
+# Design — roadmap-v2-perplexity-integration
+
+## Scope recap
+
+This change is **planning-only**. No production code changes. Artifacts:
+
+1. `openspec/roadmap.md` — full rewrite
+2. `openspec/changes/roadmap-v2-perplexity-integration/specs/tooling-roadmap/spec.md` — new capability
+3. `docs/perplexity-feedback.md` — canonical review reference
+4. This change's own proposal/tasks/design/work-packages
+
+## Decisions
+
+### D1: Single-document roadmap over per-phase stubs
+
+**Decision**: Adopt Approach A from `proposal.md` — one rewritten
+`roadmap.md` plus one capability spec.
+
+**Rejected alternatives**:
+- Approach B (pre-scaffold 18 stub directories): rejected because it
+  would clutter `openspec list` output for the project's entire
+  multi-month execution window and because stub content drifts faster
+  than the roadmap it shadows.
+- Approach C (CI-enforced DAG via `scripts/validate-roadmap.py`):
+  rejected because the maintenance burden of CI gates over documentation
+  state outweighs the benefit at current project scale. If multiple
+  developers later run phases concurrently, enforcement becomes a
+  separate follow-up proposal.
+
+### D2: Perplexity §8 ordering is authoritative
+
+**Decision**: The roadmap adopts perplexity §8 "Recommended
+Implementation Order" as its sequencing even where it conflicts with the
+original P2–P10 order.
+
+**Rationale**: The §8 ordering bakes in a dependency chain (memory →
+tools → observability → extensions → A2A → scheduler → Obsidian →
+resilience → lifecycle → routing → delegation context → security). The
+original P-numbering was scope-derived, not dependency-derived.
+
+**Counterargument considered**: Perplexity §6 argues A2A should be
+Phase 1. Rejected at discovery (Gate 0 question 2) — lower integration
+risk comes from having working agents to expose first.
+
+### D3: P1.5 bootstrap-fixes as a distinct phase
+
+**Decision**: The five minor fixes from perplexity §7 (CLI `-h`
+conflict, `sqlalchemy.text()` wrapper, `deepagents` package reference,
+`[project.scripts]` entry point, `name` variable shadowing) get their
+own proposal `P1.5 bootstrap-fixes` rather than being absorbed into
+whichever downstream phase next touches each file.
+
+**Rationale**: They're hygiene debt that blocks development ergonomics
+(`uv run assistant` doesn't work without the entry point fix; CLI
+`--help` is shadowed). A single small PR clears all five at once; the
+alternative forces each downstream phase to detour through unrelated
+bugfixes.
+
+### D4: Old P4/P6/P7/P9/P10 carried forward as P14–P18
+
+**Decision**: The five items from the original P2–P10 that have no
+perplexity §8 counterpart (google-extensions, work-persona-config,
+cli-harness-integrations, mcp-server-exposure, railway-deployment) are
+appended to the sequence as P14–P18 rather than dropped.
+
+**Rationale**: Replace semantics (per the Gate-0 answer) means "rewrite
+the doc," not "drop half the items." These phases still have value —
+they just happen to have no perplexity-raised concerns. Placing them
+last honors dependency order: they all rely on infrastructure built in
+P1.5–P13.
+
+### D5: Per-phase change-ids without date prefix
+
+**Decision**: Each downstream phase's OpenSpec change-id is the
+kebab-case slug from the roadmap (e.g., `memory-architecture`,
+`a2a-server`) — no date prefix.
+
+**Rationale**: The archived P1 used a date prefix
+(`2026-04-12-bootstrap-vertical-slice`). That convention makes sense
+for archival (when the archive date is meaningful) but is noise during
+development — the roadmap is the identity source. Archiving can add a
+date prefix at archive time if desired.
+
+### D6: `tooling-roadmap` as a capability spec
+
+**Decision**: Formalize roadmap invariants as a capability spec with
+one ADDED requirement ("The project SHALL maintain a single canonical
+roadmap…") and four sub-requirements covering authority, status
+lifecycle, DAG, and provenance.
+
+**Rationale**: Without a spec, the roadmap is just a markdown file
+that drifts. With a spec, `openspec validate` (and future reviewers)
+can check its invariants. Keeps the soft-discipline model (Approach A)
+but makes the discipline explicit.
+
+## Non-goals
+
+- **No phase-proposal scaffolds created**: Each phase's proposal.md,
+  specs, and tasks are generated at `/plan-feature <phase-id>` time.
+- **No CI enforcement**: No script validates that in-progress phases
+  match their roadmap status. The spec requirements are reviewer-level
+  obligations, not CI-gated ones.
+- **No automated `roadmap.md` update on archive**: When a phase is
+  archived, the archiving engineer manually flips its status column.
+  Automating this is a follow-up proposal if warranted.
+
+## Open questions
+
+- **`docs/perplexity-feedback.md` content format**: The review document
+  is long; do we store it verbatim, summarize it, or store verbatim in a
+  sub-file with a summary at the top? Answer: store verbatim; the
+  citations in `roadmap.md` point to specific § references and
+  grepability matters.
+- **Should P1.5 be part of this proposal?** No — this proposal only
+  declares P1.5 exists in the roadmap. The actual fixes are implemented
+  via a separate `/plan-feature bootstrap-fixes` run.

--- a/openspec/changes/roadmap-v2-perplexity-integration/proposal.md
+++ b/openspec/changes/roadmap-v2-perplexity-integration/proposal.md
@@ -1,0 +1,164 @@
+# Roadmap v2 — Perplexity Feedback Integration
+
+## Why
+
+`openspec/roadmap.md` was derived from `docs/agentic-assistant-bootstrap-v4.1.md`
+before the v4.1 spec was reviewed by perplexity. That review
+(`docs/perplexity-feedback.md` — the v4.1 review document pasted into the
+planning conversation) identified eight structural gaps (§1–§6) and twelve
+prioritized implementation items (§8) that materially reshape the plan:
+
+- **Missing from original roadmap entirely**: observability (§1.1, §8.3),
+  A2A server (§6, §8.5), scheduler (§2.1, §8.6), Obsidian vault
+  integration (§2.2, §8.7), error resilience (§1.3, §8.8), extension
+  lifecycle hooks (§3.1, §8.9), dynamic harness routing (§3.2, §8.10),
+  security hardening (§4, §8.12).
+- **Under-specified in original roadmap**: memory architecture
+  (`memory.md` vs Postgres vs Graphiti hierarchy — §1.2, §8.1),
+  sub-agent delegation context (§3.3, §8.11).
+- **Bootstrap hygiene debt**: five minor fixes (§7) — CLI `-h` conflict,
+  missing `sqlalchemy.text()` wrapper, `deepagents` package reference,
+  missing `[project.scripts]` entry point, `name` variable shadowing in
+  `PersonaRegistry.load`.
+
+Additionally, the current `openspec/roadmap.md` is **stale**: it lists
+P1 as "in progress" but P1 `bootstrap-vertical-slice` was archived on
+2026-04-12. Working from a stale roadmap invites duplicated effort and
+confusion about which capabilities exist.
+
+A single authoritative roadmap that integrates perplexity §8 ordering,
+folds the un-overlapping pieces of P2–P10 into the new sequence, and
+stages bootstrap hygiene fixes as a prerequisite proposal is the cleanest
+way to unblock parallel phase implementation via `/autopilot`.
+
+## What Changes
+
+This proposal is **planning-only** — it produces documentation, not code
+changes. It will:
+
+1. **Replace `openspec/roadmap.md`** with a v2 that sequences 18 phases
+   (P1.5 bootstrap-fixes + P2–P18) per perplexity §8 order, with each old
+   P2–P10 item folded into its perplexity-aligned position.
+2. **Add a `tooling-roadmap` capability spec** that formalizes what the
+   roadmap document is for and the invariants it must satisfy (sequencing,
+   status lifecycle, dependency graph representation).
+3. **Add `docs/perplexity-feedback.md`** capturing the review document
+   verbatim so the roadmap rationale has a stable reference.
+4. **Define the phase-dependency DAG** in the new roadmap so that
+   `/plan-feature` and `/autopilot` invocations for each phase can look up
+   prerequisites deterministically.
+
+Out of scope (handled by downstream phase proposals):
+- The actual implementation of any phase (P1.5 and each of P2–P18 will be
+  their own `/plan-feature` → `/autopilot` cycles).
+- Spec deltas for `persona-registry`, `extension-registry`, etc. —
+  those belong to the phase that implements the change.
+
+## Approaches Considered
+
+### Approach A: Single roadmap document + capability spec (Recommended)
+
+**Description**: Rewrite `openspec/roadmap.md` as the single source of
+truth for phase sequencing. Add a `tooling-roadmap` capability spec with
+one requirement ("The project SHALL maintain a roadmap document…") and
+scenarios covering sequencing, status lifecycle, and dependency-graph
+invariants. No stub proposal directories created — each downstream phase
+starts fresh when its turn comes.
+
+**Pros**:
+- Minimal artifact surface: roadmap.md + one spec file + feedback doc
+- No premature commitment to phase-internal task shape
+- Fast to land and review
+- Each downstream phase gets a full `/plan-feature` pass, preserving
+  discovery-question quality and letting implementation feedback inform
+  later designs
+
+**Cons**:
+- No machine-enforcement of the dependency DAG — relies on humans
+  consulting the roadmap before starting each phase
+- Phase IDs (P1.5, P2, …, P18) only exist in the roadmap document; the
+  actual OpenSpec change-ids will be chosen when each phase is planned
+
+**Effort**: S
+
+### Approach B: Roadmap + pre-scaffolded phase stubs
+
+**Description**: Everything in Approach A, plus create skeleton
+directories `openspec/changes/<phase-id>/` for each of the 18 phases
+with `proposal.md` containing only the title, a one-paragraph why, and
+"See roadmap.md P<n>". `/plan-feature` later fills in approaches, specs,
+tasks. Pre-wires each phase so `/autopilot phase P5` can find a
+pre-existing directory.
+
+**Pros**:
+- Autopilot invocations have a stable directory to target from day one
+- Phase IDs become authoritative (directory-backed), not just doc-mentioned
+- Easier to grep `openspec/changes/` for upcoming work
+
+**Cons**:
+- 18 skeleton directories clutter the active-changes listing; `openspec
+  list` will show them all as "pending" even though most are months away
+- Titles/scopes written now may drift from reality by the time that phase
+  runs — pre-written stubs get stale
+- More to review in this PR (proposal.md × 18 vs 1)
+
+**Effort**: M
+
+### Approach C: Roadmap + dependency-graph enforcement script
+
+**Description**: Approach A, plus a `scripts/validate-roadmap.py` that
+parses roadmap.md, verifies each phase's prerequisites are archived
+before that phase can begin, and fails CI if someone tries to archive a
+phase out of order. Optionally adds a pre-commit hook that blocks the
+creation of a `proposal.md` for a phase whose deps aren't met.
+
+**Pros**:
+- Machine-enforced sequencing — no accidental out-of-order starts
+- Makes the DAG a first-class artifact, not a markdown afterthought
+- Catches drift if someone edits roadmap.md inconsistently with
+  `openspec/changes/` state
+
+**Cons**:
+- More engineering effort (script + tests + CI wire-up)
+- Adds friction when the DAG legitimately needs to change (e.g.,
+  discovering during P4 that P8 can actually start earlier)
+- Overkill for a solo-developer project — the soft discipline of
+  consulting roadmap.md is probably sufficient
+- CI gating on documentation state is a maintenance burden
+
+**Effort**: M–L
+
+### Recommended: Approach A
+
+Approach A matches the project's current scale (one developer, phases run
+sequentially via `/autopilot` rather than in parallel) and preserves the
+value of full `/plan-feature` discovery for each phase. The dependency
+DAG still exists — it's written into roadmap.md — it just isn't
+machine-enforced. If the project scales to multiple developers and
+phases start running concurrently, Approach C's enforcement script
+becomes a follow-up proposal.
+
+Approach B's stub-proliferation cost is not recovered by its
+discoverability benefit when there's effectively one active phase at a
+time.
+
+### Selected Approach
+
+**Approach A — roadmap doc + capability spec.** Confirmed by user at
+Gate 1 with no modifications. Proceeding to generate:
+
+- `openspec/roadmap.md` (rewritten in full)
+- `openspec/changes/roadmap-v2-perplexity-integration/specs/tooling-roadmap/spec.md` (ADDED)
+- `docs/perplexity-feedback.md` (canonical copy of the review)
+- `openspec/changes/roadmap-v2-perplexity-integration/tasks.md`
+- `openspec/changes/roadmap-v2-perplexity-integration/design.md` (phase-by-phase decomposition with §-citations)
+
+Approaches B and C are recorded here as rejected:
+
+- **B rejected**: 18 skeleton proposal directories would clutter `openspec
+  list` output for months while most stubs sit unchanged; pre-written
+  stubs drift from reality before their phase runs.
+- **C rejected**: machine-enforcement of a documentation-driven DAG adds
+  CI maintenance burden disproportionate to the project's current scale.
+  If phases start running concurrently later, enforcement becomes a
+  follow-up proposal.

--- a/openspec/changes/roadmap-v2-perplexity-integration/session-log.md
+++ b/openspec/changes/roadmap-v2-perplexity-integration/session-log.md
@@ -1,0 +1,78 @@
+# Session log — roadmap-v2-perplexity-integration
+
+---
+
+## Phase: Plan (2026-04-13)
+
+**Agent**: claude-code (Opus 4.6) | **Session**: N/A
+
+### Decisions
+
+1. **Replace P2–P10 with unified §8-ordered sequence** — The original
+   roadmap predated perplexity review and was stale (P1 still listed as
+   "in progress" despite being archived 2026-04-12). Replacing wholesale
+   is cleaner than layering new phases on top of outdated content.
+2. **Perplexity §8 ordering is authoritative** — Adopted §8's
+   memory → HTTP → observability → MS Graph → A2A → scheduler → Obsidian
+   → resilience → lifecycle → routing → delegation-context → security
+   order even where it conflicts with original P-numbering.
+3. **P1.5 bootstrap-fixes as distinct phase** — The five §7 hygiene
+   fixes (CLI `-h`, `sqlalchemy.text()`, `deepagents` package,
+   `[project.scripts]`, variable shadowing) run as a single prerequisite
+   PR rather than being absorbed into each downstream phase.
+4. **Old P4/P6/P7/P9/P10 carried forward as P14–P18** — No-perplexity-
+   coverage items (google-extensions, work-persona-config,
+   cli-harness-integrations, mcp-server-exposure, railway-deployment)
+   preserved as tail of the sequence.
+5. **Approach A: single roadmap document + capability spec** — Selected
+   at Gate 1 over Approach B (pre-scaffolded 18 stubs) and Approach C
+   (CI-enforced DAG).
+6. **Change-ids without date prefix** — Each downstream phase's
+   OpenSpec change-id is the kebab-case slug from the roadmap
+   (`memory-architecture`, `a2a-server`, etc.) with no date prefix.
+
+### Alternatives Considered
+
+- **Fork into roadmap-v2.md, keep v1**: rejected — two competing
+  roadmaps invite reader confusion about which is authoritative.
+- **Promote A2A to Phase 1** (perplexity §6): rejected at discovery
+  gate — lower integration risk comes from having working agents to
+  expose first.
+- **Group items into 6–8 medium phases**: rejected in favor of fine
+  granularity (one proposal per §8 item) to maximize `/autopilot`
+  parallelizability and review cohesion.
+- **CI-enforced DAG (Approach C)**: rejected — doc-driven enforcement
+  rots faster than the docs it guards; not justified at solo-developer
+  scale.
+
+### Trade-offs
+
+- Accepted **18 phases** over **6–8 grouped phases** because fine
+  granularity unlocks `/autopilot` per-phase + keeps review burden per
+  PR small.
+- Accepted **no CI enforcement** over **machine-enforced DAG** because
+  the maintenance cost of CI gates on documentation state outweighs
+  the benefit for a solo project.
+- Accepted **carry-forward of old P4/P6/P7/P9/P10** over **dropping
+  them** because "replace roadmap" means "rewrite the doc," not
+  "drop half the scope."
+
+### Open Questions
+
+- [ ] Should `docs/perplexity-feedback.md` store the review verbatim or
+      as a summary with § anchors? (Tentatively: verbatim, per design
+      D6's "Open questions" resolution. Confirmed during implementation.)
+- [ ] Whether to automate roadmap-status flips on archive. (Deferred
+      to a follow-up proposal if warranted.)
+
+### Context
+
+Planning goal: integrate perplexity v4.1 review feedback into the
+project roadmap so downstream phases can be implemented via
+`/autopilot`. Outcome: proposal + design + tasks + specs + contracts
+(stub) + work-packages for `roadmap-v2-perplexity-integration`, a
+planning-only change that rewrites `openspec/roadmap.md` to sequence
+18 phases (P1 archived, P1.5 bootstrap-fixes, P2–P13 perplexity §8
+items, P14–P18 carried-forward legacy items). Validated with
+`openspec validate roadmap-v2-perplexity-integration --strict` (exit 0,
+PostHog network errors are unrelated telemetry).

--- a/openspec/changes/roadmap-v2-perplexity-integration/specs/tooling-roadmap/spec.md
+++ b/openspec/changes/roadmap-v2-perplexity-integration/specs/tooling-roadmap/spec.md
@@ -1,0 +1,89 @@
+# tooling-roadmap — spec delta
+
+## ADDED Requirements
+
+### Requirement: Roadmap Document Authoritative
+
+The project SHALL maintain a single canonical roadmap at
+`openspec/roadmap.md` that SHALL be the authoritative ordering of all
+planned OpenSpec phases. Every non-archived phase referenced by
+downstream tooling (such as `/plan-feature`, `/autopilot`, session logs)
+MUST appear in the roadmap's phase sequence table with a stable change-id
+and a status value.
+
+#### Scenario: Every in-progress change has a roadmap row
+
+- **WHEN** an OpenSpec change exists under `openspec/changes/<change-id>/`
+  (not in `archive/`)
+- **THEN** a row in the `openspec/roadmap.md` phase sequence table SHALL
+  have `Change ID` equal to `<change-id>` and `Status` equal to either
+  `pending` or `in-progress`
+
+#### Scenario: Archived changes remain listed with archived status
+
+- **WHEN** a change is moved to `openspec/changes/archive/`
+- **THEN** the roadmap row for that change-id SHALL have `Status` equal
+  to `archived`
+- **AND** the row SHALL NOT be deleted from the roadmap table
+
+### Requirement: Phase Status Lifecycle
+
+Each roadmap phase SHALL progress through exactly three statuses —
+`pending`, `in-progress`, `archived` — in that order. The roadmap
+document MUST reflect the current status of every phase.
+
+#### Scenario: Status transitions forward only
+
+- **WHEN** a phase's status is updated
+- **THEN** the new status SHALL be `pending → in-progress` or
+  `in-progress → archived`
+- **AND** a phase MUST NOT transition backward (e.g., `archived →
+  pending`) without a dedicated follow-up proposal that documents the
+  reversion rationale
+
+#### Scenario: In-progress marker aligns with proposal directory
+
+- **WHEN** a phase's status in the roadmap is `in-progress`
+- **THEN** a directory `openspec/changes/<change-id>/` SHALL exist
+  containing at minimum a `proposal.md`
+
+### Requirement: Dependency Graph Representation
+
+The roadmap SHALL include a "Dependency graph" section expressing the
+prerequisites each phase has on earlier phases. Each phase's prerequisite
+set MUST be a subset of the other phases listed in the roadmap.
+
+#### Scenario: Prerequisites reference real phases
+
+- **WHEN** the dependency graph lists phase B as depending on phase A
+- **THEN** phase A SHALL appear in the roadmap's phase sequence table
+- **AND** phase A's status SHALL be `archived` before phase B's status
+  may transition to `in-progress`
+
+#### Scenario: Graph is acyclic
+
+- **WHEN** the dependency graph is interpreted as a directed graph (edges
+  = "depends on")
+- **THEN** the graph MUST be acyclic — no phase may transitively depend
+  on itself
+
+### Requirement: Provenance Attribution
+
+Every roadmap phase SHALL include columns or annotations indicating its
+source — the originating document (e.g., bootstrap-v4.1 P-number,
+perplexity feedback § reference, or "new" when neither applies) — so
+that reviewers can trace each phase back to its motivating analysis.
+
+#### Scenario: Phase sourced from perplexity feedback
+
+- **WHEN** a phase's scope is derived from the perplexity review document
+- **THEN** the roadmap row SHALL cite the perplexity section in a
+  "Perplexity §" column or equivalent annotation
+- **AND** `docs/perplexity-feedback.md` SHALL exist in the repository as
+  the canonical reference for those citations
+
+#### Scenario: Phase carried forward from prior roadmap
+
+- **WHEN** a phase's scope is carried forward from the pre-v2 roadmap
+- **THEN** the roadmap row SHALL cite the original P-number (e.g.,
+  "original P4") in its Source column

--- a/openspec/changes/roadmap-v2-perplexity-integration/tasks.md
+++ b/openspec/changes/roadmap-v2-perplexity-integration/tasks.md
@@ -1,0 +1,93 @@
+# Tasks — roadmap-v2-perplexity-integration
+
+Planning-only change. All tasks are documentation edits; tests validate
+roadmap invariants via `openspec validate --strict` rather than runtime
+behavior.
+
+## Phase 1 — Canonical reference
+
+- [ ] 1.1 Write test: verify `docs/perplexity-feedback.md` exists and
+  contains all twelve §8 item headings (§8.1 through §8.12)
+  **Spec scenarios**: tooling-roadmap — "Phase sourced from perplexity
+  feedback"
+  **Contracts**: N/A
+  **Design decisions**: D6
+  **Dependencies**: None
+- [ ] 1.2 Create `docs/perplexity-feedback.md` by copying the review
+  verbatim (from the planning conversation) into the file. Preserve all
+  § numbering exactly so `roadmap.md` citations resolve.
+  **Dependencies**: 1.1
+
+## Phase 2 — Roadmap rewrite
+
+- [ ] 2.1 Write test: verify `openspec/roadmap.md` phase-sequence table
+  lists all 18 phases (P1 archived, P1.5, P2–P18) with non-empty
+  change-ids and status values.
+  **Spec scenarios**: tooling-roadmap — "Every in-progress change has a
+  roadmap row", "Archived changes remain listed with archived status"
+  **Contracts**: N/A
+  **Design decisions**: D2, D4, D5
+  **Dependencies**: 1.2
+- [ ] 2.2 Write test: verify the Dependency graph section's phase names
+  are a subset of the phase-sequence-table's change-ids (no dangling
+  references). Parse the graph as a DAG and assert acyclicity.
+  **Spec scenarios**: tooling-roadmap — "Prerequisites reference real
+  phases", "Graph is acyclic"
+  **Design decisions**: D2
+  **Dependencies**: 2.1
+- [ ] 2.3 Rewrite `openspec/roadmap.md` per design.md:
+  - Guiding principles section
+  - 18-row phase sequence table (P1 archived, P1.5, P2–P18) with
+    change-id, status, perplexity §, source, description columns
+  - Status lifecycle section (pending → in-progress → archived)
+  - Dependency graph section rendered as ASCII tree
+  - Per-phase execution playbook (plan → autopilot → archive)
+  - Cross-cutting themes table
+  - Out-of-scope section carrying forward the Phase-16 deferrals
+  **Dependencies**: 2.1, 2.2
+
+## Phase 3 — Capability spec
+
+- [ ] 3.1 Write test: `openspec validate roadmap-v2-perplexity-integration
+  --strict` exits 0.
+  **Spec scenarios**: all four ADDED requirements under tooling-roadmap
+  **Design decisions**: D6
+  **Dependencies**: None
+- [ ] 3.2 Create
+  `openspec/changes/roadmap-v2-perplexity-integration/specs/tooling-roadmap/spec.md`
+  with ADDED Requirements:
+  - "Roadmap Document Authoritative" + 2 scenarios
+  - "Phase Status Lifecycle" + 2 scenarios
+  - "Dependency Graph Representation" + 2 scenarios
+  - "Provenance Attribution" + 2 scenarios
+  All SHALL/MUST language placed near the start of each requirement
+  body (gotcha G5 from docs/gotchas.md).
+  **Dependencies**: 3.1
+
+## Phase 4 — Wire-up & validation
+
+- [ ] 4.1 Run `openspec validate roadmap-v2-perplexity-integration
+  --strict` and confirm exit 0. Fix any delta-header or scenario-format
+  errors.
+  **Dependencies**: 3.2, 2.3, 1.2
+- [ ] 4.2 Run a manual walkthrough: pick three phases from the new
+  roadmap (one perplexity-new like P4 observability, one folded-in like
+  P2 memory-architecture that combines §8.1 with old P3, one carried
+  forward like P18 railway-deployment). For each, verify the row's
+  source/perplexity citation is accurate against `design.md` and
+  `docs/perplexity-feedback.md`.
+  **Dependencies**: 4.1
+- [ ] 4.3 Update the "Current Status" / "What's Not Yet Wired" note at
+  the top of `CLAUDE.md` if it references the old P-numbering. (Only if
+  stale references are found; skip otherwise.)
+  **Dependencies**: 4.2
+
+## Phase 5 — Session log and archival handoff
+
+- [ ] 5.1 Append Plan-phase session log entry per `/plan-feature` Step
+  11.5 (already handled by the skill; listed here for completeness).
+  **Dependencies**: 4.3
+- [ ] 5.2 After archival of this change, the first downstream phase
+  (P1.5 bootstrap-fixes) will be invoked via `/plan-feature
+  bootstrap-fixes`. No work for *this* proposal beyond archival.
+  **Dependencies**: 5.1

--- a/openspec/changes/roadmap-v2-perplexity-integration/work-packages.yaml
+++ b/openspec/changes/roadmap-v2-perplexity-integration/work-packages.yaml
@@ -1,0 +1,49 @@
+# Sequential-tier work package — planning-only change.
+# A single wp-main encompasses the full scope per the /plan-feature
+# skill's sequential-tier template.
+
+schema_version: "1.0"
+
+packages:
+  - id: wp-main
+    name: "roadmap-v2-perplexity-integration — full scope"
+    description: >
+      Rewrite openspec/roadmap.md, add tooling-roadmap capability spec,
+      add docs/perplexity-feedback.md canonical reference. All tasks
+      from tasks.md phases 1–5.
+    tasks:
+      - "1.1"
+      - "1.2"
+      - "2.1"
+      - "2.2"
+      - "2.3"
+      - "3.1"
+      - "3.2"
+      - "4.1"
+      - "4.2"
+      - "4.3"
+      - "5.1"
+      - "5.2"
+    priority: 1
+    dependencies: []
+    scope:
+      write_allow:
+        - "openspec/roadmap.md"
+        - "openspec/changes/roadmap-v2-perplexity-integration/**"
+        - "docs/perplexity-feedback.md"
+        - "CLAUDE.md"
+      read_allow:
+        - "**"
+      deny:
+        - "src/**"
+        - "tests/**"
+        - "personas/**"
+    locks:
+      files:
+        - "openspec/roadmap.md"
+      keys:
+        - "docs:openspec/roadmap.md"
+        - "spec:tooling-roadmap"
+      ttl_minutes: 120
+      reason: "Roadmap rewrite + tooling-roadmap capability spec introduction"
+    verification: tier_b

--- a/openspec/roadmap.md
+++ b/openspec/roadmap.md
@@ -1,41 +1,111 @@
-# agentic-assistant — OpenSpec Roadmap
+# agentic-assistant — OpenSpec Roadmap v2
 
-Derived from `docs/agentic-assistant-bootstrap-v4.1.md`. The bootstrap spec is split
-into sequenced OpenSpec proposals so each change is independently reviewable,
-implementable, and validatable. One proposal per session to preserve context
-and let implementation feedback inform later designs.
+> **Supersedes** the original roadmap derived solely from
+> `docs/agentic-assistant-bootstrap-v4.1.md`. This v2 integrates perplexity
+> review feedback (`docs/perplexity-feedback.md`) and reorders phases per
+> §8 "Recommended Implementation Order." The original roadmap is preserved
+> in git history.
+>
+> Change that introduced this rewrite: `roadmap-v2-perplexity-integration`.
+
+## Guiding principles
+
+1. **One OpenSpec proposal per §8 item** — fine-grained, independently
+   reviewable, each eligible for `/plan-feature` → `/autopilot`.
+2. **§8 ordering is authoritative** — even where the original roadmap
+   had a different order. The only exception: `P1.5 bootstrap-fixes`
+   runs first to clear hygiene debt before architectural work starts.
+3. **Old P2–P10 items without perplexity coverage are folded in at the
+   end** so no prior scope is silently dropped.
+4. **Docs — not CI — enforce the DAG**. Consult this file before
+   invoking `/plan-feature` or `/autopilot` for any phase.
 
 ## Proposal sequence
 
-| # | Change ID | Status | Description |
-|---|-----------|--------|-------------|
-| P1 | `bootstrap-vertical-slice` | in progress | Core library (persona, role, composition) + Deep Agents harness + CLI + 5 public roles + personal persona populated + extension stubs + delegation spawner + tests + CI |
-| P2 | `http-tools-layer` | pending | `src/assistant/core/http_tools/` — `/help`-based discovery, StructuredTool builder, auth header handling, registry, `--list-tools` CLI command, integration tests against a mock server |
-| P3 | `persona-db-layer` | pending | Per-persona `AsyncEngine`, schema init (`memory`, `preferences`, `interactions` tables), memory CRUD, Graphiti client factory, isolation tests |
-| P4 | `google-extensions` | pending | Real `gmail`, `gcal`, `gdrive` extension implementations. LangChain StructuredTools + MS Agent Framework AIFunctions. OAuth refresh flow. |
-| P5 | `ms-graph-extensions` | pending | Real `ms_graph`, `teams`, `sharepoint`, `outlook` extensions + MS Agent Framework harness (full impl, replacing the P1 stub) |
-| P6 | `work-persona-config` | pending | (Deferred until work machine) Create `assistant-config-work` submodule, wire into `.gitmodules`, populate work persona config + role overrides |
-| P7 | `cli-harness-integrations` | pending | Deeper Claude Code/Codex/Gemini integrations — slash commands in `.claude/commands/`, `.codex/skills/`, `.gemini/settings.json`, persona-aware routing |
-| P8 | `advanced-delegation` | pending | `delegate_parallel`, monitoring/cancellation, delegation analytics tables, harness auto-routing by task type |
-| P9 | `mcp-server-exposure` | pending | Expose the assistant as an MCP server so other Claude Code sessions can invoke it as a tool |
-| P10 | `railway-deployment` | pending | Run persona instances as Railway services + deployment manifests |
+| # | Change ID | Status | Perplexity § | Source | Description |
+|---|-----------|--------|--------------|--------|-------------|
+| P1 | `bootstrap-vertical-slice` | **archived** (2026-04-12) | — | original P1 | Core library + Deep Agents harness + CLI + 5 roles + personal persona + delegation + tests + CI |
+| P1.5 | `bootstrap-fixes` | pending | §7.1–§7.5 | perplexity §7 | CLI `-h` flag conflict; add `sqlalchemy.text()` wrapper; reconcile `deepagents` package reference; add `[project.scripts]` entry point; fix `name` variable shadowing in `PersonaRegistry.load` |
+| P2 | `memory-architecture` | pending | §1.2, §8.1 | perplexity §8.1 + old P3 | `core/memory.py` MemoryManager + `core/graphiti.py` client factory + per-persona AsyncEngine + `memory`/`preferences`/`interactions` tables + `scripts/export-memory.sh` that regenerates `memory.md` from Postgres+Graphiti |
+| P3 | `http-tools-layer` | pending | §8.2 | perplexity §8.2 + old P2 | `src/assistant/http_tools/` — `/help`-based discovery, `_build_tool()` Pydantic-model + async-callable generator, auth header handling, registry, `--list-tools` CLI command, integration tests against mock server |
+| P4 | `observability` | pending | §1.1, §8.3 | perplexity §8.3 (new) | `core/observability.py` — `@traced` decorator, spans on `HarnessAdapter.invoke()` and `DelegationSpawner.delegate()`, token + latency + cost tracking per persona/role. Langfuse backend default; OpenLLMetry adapter optional |
+| P5 | `ms-graph-extension` | pending | §8.4 | perplexity §8.4 + old P5 | Real `ms_graph`, `teams`, `sharepoint`, `outlook` extensions (replaces P1 stubs). MSAL auth, httpx client, OAuth refresh. Full MS Agent Framework harness implementation replacing P1's `NotImplementedError` stub |
+| P6 | `a2a-server` | pending | §6, §8.5 | perplexity §8.5 (new; was Phase-16 "out of scope") | `src/assistant/a2a/` — server.py, task_handler.py, agent_card.py. Exposes `/a2a/v1/message:stream` endpoint. Serves `.well-known/agent.json`. Lets Copilot Studio Chief of Staff delegate to this assistant |
+| P7 | `scheduler` | pending | §2.1, §8.6 | perplexity §8.6 (new) | `core/scheduler.py` — cron (croniter) + calendar-event + polling triggers. `schedules:` section in `persona.yaml`. `--daemon` CLI flag. Morning briefing / email triage / pre-meeting brief hooks |
+| P8 | `obsidian-vault` | pending | §2.2, §8.7 | perplexity §8.7 (new) | Obsidian vault RAG integration. Preferred: add indexing endpoint to `agentic-content-analyzer` and reference it as a tool source. Fallback: standalone `extensions/obsidian.py` with wikilink parsing, pgvector index |
+| P9 | `error-resilience` | pending | §1.3, §8.8 | perplexity §8.8 (new) | `core/resilience.py` — `tenacity`-based retry on transient HTTP failures, circuit breaker per backend, graceful degradation (agent notes unavailability instead of silent omission). Applied to http_tools client + extension `health_check()` |
+| P10 | `extension-lifecycle` | pending | §3.1, §8.9 | perplexity §8.9 (new) | Extend `Extension` protocol with `initialize()`, `shutdown()`, `refresh_credentials()` lifecycle hooks. `PersonaRegistry.load_extensions()` calls `initialize()` post-load; registers shutdown handler |
+| P11 | `harness-routing` | pending | §3.2, §8.10 | perplexity §8.10 (new) | Dynamic harness selection in `harnesses/factory.py`. `--harness auto` default. Routes M365-tool tasks → MS Agent Framework, complex reasoning → Deep Agents |
+| P12 | `delegation-context` | pending | §3.3, §8.11 | perplexity §8.11 + old P8 | `DelegationContext` dataclass (parent_role, delegation_chain, memory_snippets, conversation_summary, constraints). Cycle detection. `delegate_parallel`. Monitoring/cancellation. Delegation analytics tables |
+| P13 | `security-hardening` | pending | §4, §8.12 | perplexity §8.12 (new) | Per-persona env var scoping in `_env()` helper. Per-persona `.env` files. Extension `manifest.yaml` with SHA-256 hashes verified before `spec.loader.exec_module()` |
+| P14 | `google-extensions` | pending | — | original P4 | Real `gmail`, `gcal`, `gdrive` extension implementations. OAuth refresh via the P10 lifecycle hooks |
+| P15 | `work-persona-config` | pending | — | original P6 | Create `assistant-config-work` submodule, wire into `.gitmodules`, populate work persona config + role overrides. Deferred until work machine available |
+| P16 | `cli-harness-integrations` | pending | — | original P7 | Deeper Claude Code / Codex / Gemini integrations — slash commands in `.claude/commands/`, `.codex/skills/`, `.gemini/settings.json`. Persona-aware routing |
+| P17 | `mcp-server-exposure` | pending | — | original P9 | Expose the assistant as an MCP server so other Claude Code sessions can invoke it as a tool. Complementary to P6 A2A (different protocols, different clients) |
+| P18 | `railway-deployment` | pending | — | original P10 | Run persona instances as Railway services + deployment manifests |
+
+## Status lifecycle
+
+Each phase transitions: `pending` → `in-progress` (when `/plan-feature`
+creates its proposal directory) → `archived` (when
+`/openspec-archive-change` finalizes it). This table is the canonical
+record — update it as part of the phase's final commit.
 
 ## Dependency graph
 
 ```
-P1 (bootstrap-vertical-slice)
- ├─→ P2 (http-tools-layer)
- ├─→ P3 (persona-db-layer)
- │    └─→ P8 (advanced-delegation)
- ├─→ P4 (google-extensions)  ──┐
- ├─→ P5 (ms-graph-extensions) ─┴─→ P9 (mcp-server-exposure)
- ├─→ P6 (work-persona-config) [independent, triggered by machine availability]
- └─→ P7 (cli-harness-integrations)
-           └─→ P10 (railway-deployment)
+P1 (archived)
+ └─→ P1.5 bootstrap-fixes (hygiene; unblocks everything below)
+      ├─→ P2 memory-architecture ──┬─→ P7 scheduler
+      │                            ├─→ P8 obsidian-vault
+      │                            └─→ P12 delegation-context
+      ├─→ P3 http-tools-layer ─────┬─→ P5 ms-graph-extension ──┬─→ P6 a2a-server
+      │                            │                          └─→ P14 google-extensions
+      │                            └─→ P9 error-resilience
+      ├─→ P4 observability (spans everything below — lands early)
+      ├─→ P10 extension-lifecycle ─→ P13 security-hardening
+      └─→ P11 harness-routing (needs P5 MS Agent Framework real; decouples from Deep-Agents-only)
+
+P15 work-persona-config — independent; triggered by machine availability; needs P5 + P8
+P16 cli-harness-integrations — independent; needs P1.5
+P17 mcp-server-exposure — needs P6 (protocol parallel)
+P18 railway-deployment — needs P15, P16
 ```
 
-## Out of scope for all proposals in this roadmap
+## Phase-by-phase execution via autopilot
 
-From bootstrap spec Phase 16 — will be planned only if/when priorities shift:
-cross-persona bridge, A2A protocol, multi-model routing, proactive monitoring,
-NotebookLM integration, role learning, persona config encryption.
+Per phase:
+
+```bash
+# 1. Plan
+/plan-feature <change-id>   # e.g. memory-architecture
+
+# 2. Implement (once plan approved at Gate 2)
+/autopilot <change-id>
+
+# 3. Archive
+/openspec-archive-change <change-id>
+
+# 4. Update this roadmap's status column
+```
+
+The change-ids in this roadmap ARE the OpenSpec change-ids. Do not
+re-prefix with dates; the roadmap is the identity source.
+
+## Cross-cutting themes
+
+| Theme | Phases that touch it |
+|-------|----------------------|
+| **Memory hierarchy** (memory.md derived from Postgres+Graphiti — perplexity §1.2) | P2 establishes; P7/P8/P12 consume |
+| **Observability** (tracing, cost per persona×role — §1.1) | P4 establishes; all later phases add spans to their new code paths |
+| **Resilience** (retry, circuit breaker — §1.3) | P9 establishes; P3/P5/P14/P17 adopt |
+| **Security boundaries** (credential scoping, manifest validation — §4) | P13 establishes; all phases loading config must comply |
+| **Proactive execution** (scheduler + A2A + Obsidian RAG — §2) | P6/P7/P8 — the differentiated Chief-of-Staff story |
+
+## Out of scope for roadmap v2
+
+Items from bootstrap spec Phase 16 not adopted by perplexity §8 and
+still deferred: cross-persona bridge, multi-model routing (beyond the
+harness-routing in P11), role learning, persona config encryption,
+NotebookLM integration. Each may re-enter a future v3 roadmap if
+perplexity-equivalent review surfaces demand.


### PR DESCRIPTION
## Summary

This is a planning-only change that rewrites the project roadmap to integrate perplexity review feedback on the bootstrap v4.1 spec. The original roadmap was stale (P1 archived but still listed as "in progress") and predated the perplexity review. This change replaces it with a v2 roadmap that sequences 18 phases according to perplexity's recommended implementation order (§8), folds in the original P2–P10 items, and formalizes roadmap invariants as a capability spec.

## Key Changes

- **Rewrote `openspec/roadmap.md`**: Replaced the original P1–P10 sequence with an 18-phase roadmap (P1 archived, P1.5 bootstrap-fixes, P2–P13 from perplexity §8, P14–P18 carried-forward legacy items). Added guiding principles, status lifecycle documentation, and a dependency graph.

- **Added `tooling-roadmap` capability spec** (`openspec/changes/roadmap-v2-perplexity-integration/specs/tooling-roadmap/spec.md`): Formalized roadmap invariants as four ADDED requirements covering document authority, status lifecycle, dependency graph representation, and provenance attribution.

- **Added `docs/perplexity-feedback.md`**: Canonical reference copy of the perplexity v4.1 review document so roadmap citations (e.g., "§8.3") have a stable target.

- **Added proposal artifacts** for the `roadmap-v2-perplexity-integration` change:
  - `proposal.md`: Explains why the roadmap needed rewriting, what changes, and the three approaches considered (selected Approach A: single document + spec, rejected pre-scaffolded stubs and CI enforcement).
  - `design.md`: Documents six design decisions (single-document model, §8 ordering authority, P1.5 as distinct phase, carry-forward of old items, change-id naming, spec formalization).
  - `tasks.md`: Five phases of documentation work (canonical reference, roadmap rewrite, spec creation, validation, archival handoff).
  - `work-packages.yaml`: Single sequential work package encompassing all tasks.
  - `session-log.md`: Plan-phase session log with decisions, alternatives, trade-offs, and context.
  - `contracts/README.md`: Stub indicating no contracts applicable.

## Notable Details

- **P1.5 bootstrap-fixes** introduced as a distinct phase to clear five hygiene issues (CLI `-h` conflict, `sqlalchemy.text()` wrapper, `deepagents` package reference, `[project.scripts]` entry point, variable shadowing) before architectural work begins.

- **Perplexity §8 ordering is authoritative**: The roadmap adopts the review's recommended sequence (memory → HTTP tools → observability → MS Graph → A2A → scheduler → Obsidian → resilience → lifecycle → routing → delegation context → security) even where it differs from the original P-numbering.

- **No code changes**: This is purely documentation. No production code, tests, or runtime behavior modified. Validation is via `openspec validate --strict` on the spec and roadmap structure.

- **Soft-discipline DAG enforcement**: The dependency graph is documented in markdown, not machine-enforced via CI. Approach C (CI-enforced validation) was rejected as over-engineered for the current solo-developer scale.

https://claude.ai/code/session_01XsLCqKqq3yR9PanwDD2H28