### PR TITLE
docs(architecture): add primitives-and-providers and interface-stability

### DIFF
--- a/docs/architecture/interface-stability.md
+++ b/docs/architecture/interface-stability.md
@@ -1,0 +1,480 @@
+# Interface Stability Ledger
+
+This document records the current stability classification of every
+repo-owned interface enumerated in
+[`primitives-and-providers.md`](./primitives-and-providers.md). It is the
+discipline that turns the SPI claim from aspiration into a verifiable
+promise: every interface in the table below has a named contract surface,
+a stability level, a conformance test path (or a "not yet" placeholder),
+and a list of known leaks or open design questions.
+
+The ledger changes more often than the primitives document. Treat
+`primitives-and-providers.md` as the **architecture** statement (what
+exists, why) and this document as the **status** statement (what's
+solid, what's drifting, what's open).
+
+## Stability levels
+
+| Level | Meaning | When to use it | When to graduate |
+|---|---|---|---|
+| **Stable** | Interface is well-shaped; ≥2 providers implement it; conformance suite exists and is green; breaking changes require a deprecation cycle | A primitive has matured through real cross-provider use without churn | After two consecutive minor releases without interface-breaking changes |
+| **Provisional** | Interface exists in code; ≥1 provider implements it; conformance suite exists or is being written; breaking changes are still allowed with a clear note | A primitive has been lifted into the repo but the shape is still settling | Promote to Stable after a second provider lands and the conformance suite catches the divergence |
+| **Experimental** | Interface is being designed in code; expect changes per release; no conformance suite yet; consumers must accept the churn | A primitive is being built; the shape is forming through use | Promote to Provisional once the design has settled and a conformance harness is sketched |
+| **Pre-interface** | Concept exists as documentation or aspiration; no interface code yet; behaviour lives inside specific providers and is not portable | A primitive has been identified but the contract has not yet been written | Promote to Experimental when a second consumer forces the design |
+
+The progression is **Pre-interface → Experimental → Provisional → Stable**.
+Demotions happen (and are noted) when a discovered leak forces a redesign.
+
+## Semantic conformance
+
+Signature conformance — does the provider expose the right methods with
+the right argument and return types — is necessary but not sufficient.
+The harder bar is **semantic conformance**: does the provider behave
+the way consumers expect under the cases the interface specifies?
+
+The repo distinguishes:
+
+- **Required semantics** — every provider claiming the interface must
+  honour these. Conformance test failure is a binding-eligibility
+  failure; the provider is not eligible for the primitive slot in any
+  persona.
+- **Capability semantics** — opt-in behaviours providers may advertise
+  via `supports(capability_name) -> bool`. Roles declare requirements;
+  the binding validator (see `primitives-and-providers.md` →
+  "Role portability") rejects persona configurations where a required
+  capability is not supplied.
+- **Provider-specific semantics** — behaviour that intentionally diverges
+  and is documented per provider. A role that depends on this must opt
+  in explicitly and is no longer persona-portable.
+
+Each entry below names known semantic conformance points alongside its
+known leaks. Required semantics that are not yet specified are also
+called out — they are gaps in the contract.
+
+## Conformance against managed providers
+
+A practical constraint that affects every entry: conformance suites
+cannot run end-to-end against managed providers in CI without cloud
+credentials, network access, and spend. The repo's practice is a
+two-tier conformance regime:
+
+- **Local conformance** — runs against real providers in CI on every
+  PR. Local providers (Ollama, LangGraph checkpointers, OpenBao,
+  self-hosted Langfuse) are the conformance baseline.
+- **Managed conformance** — runs in two modes: against mocks of the
+  managed provider in CI on every PR, and against the real managed
+  provider in a periodic verification job (cadence per provider,
+  documented in the entry). Mock drift is a documented risk; periodic
+  verification is the mitigation.
+
+A provider's stability classification depends on which tier it can
+satisfy. A managed provider cannot reach **Stable** without an active,
+green periodic verification job. A managed provider's mock conformance
+can support **Provisional** but does not on its own justify higher.
+
+## Cross-primitive constraints
+
+Some role requirements span multiple primitives. The binding validator
+must express constraints that involve more than one interface:
+
+- `interrupt_resume` requires harness support **and** session-store
+  checkpoint support **and** memory replay safety.
+- `tool_streaming` requires harness streaming support **and** capability
+  registry projection streaming **and** observability span propagation
+  across stream boundaries.
+- `cross_persona_audit` requires identity provider audit trail **and**
+  observability span retention **and** memory `forget` support
+  consistent with audit constraints.
+
+These are not new primitives — they are **compatibility groups** that
+the binding validator enforces. Each compatibility group has a name,
+an enumeration of (primitive, capability) requirements, and the role
+declarations that consume it. The enumeration lives in this document
+under the relevant entries.
+
+## Per-interface entries
+
+Each entry below follows the same template:
+
+- **Interface name** and code location (file:line if it exists)
+- **Stability** — current level
+- **Providers** — what implements it today
+- **Conformance suite** — path to the shared test file, or "not yet"
+- **Known leaks** — implementation assumptions that have crept into the
+  contract
+- **Open questions** — design decisions still pending
+
+---
+
+### `HarnessAdapter` and tier subclasses
+
+- **Code:** `src/assistant/harnesses/base.py:12, 24, 48`
+- **Stability:** **Experimental** (downgrade candidate from earlier
+  implicit "Provisional" — design will change as `AgentRegistry` and
+  `CapabilityRegistry` land)
+- **Semantic conformance points (currently unspecified — gaps):**
+  - What does `invoke()` returning `str` *mean* when the model produced
+    multi-block content (text + citations + tool traces)? Not specified.
+  - What guarantees does `spawn_sub_agent()` give about isolation (does
+    the child share memory state? identity tokens? span context)? Not
+    specified.
+  - When does `create_agent` finish — after the LLM is reachable, after
+    the first system prompt is loaded, after tools are bound? Not
+    specified. Each adapter currently chooses.
+- **Capability semantics needed (not yet declared):**
+  `streaming`, `interrupt_resume`, `multi_agent_native`, `plan_mode`,
+  `parallel_tool_calls`, `structured_output`.
+- **Providers:**
+  - `DeepAgentsHarness` (LangGraph) — `src/assistant/harnesses/sdk/deep_agents.py`
+  - `MSAgentFrameworkHarness` (stub → real in P5) —
+    `src/assistant/harnesses/sdk/ms_agent_fw.py`
+  - Pi harness — proposed, not yet implemented
+- **Conformance suite:** not yet — current tests are per-harness, not
+  cross-harness. A `tests/conformance/test_harness_adapter.py` covering
+  `name()`, `harness_type()`, `create_agent()`, `invoke()`, and
+  `spawn_sub_agent()` against a mock persona/role/tool fixture is
+  prerequisite to a second non-stub implementation.
+- **Known leaks:**
+  - `spawn_sub_agent()` returns a `str` (`base.py:39-45`), assuming a
+    single text reply. Sub-agent results may legitimately be structured
+    (citations, tool traces, plan deltas). Move to a typed result envelope
+    once a second harness exercises this path.
+  - `create_agent()`'s `tools` and `extensions` arguments are
+    `list[Any]` (`base.py:31-33`) — the protocol doesn't constrain shape.
+    This will tighten once `CapabilityRegistry` is the discovery source.
+  - `spawn_sub_agent()` lives on the harness at all — should move to
+    `AgentRegistry` once that primitive exists.
+- **Open questions:**
+  - Streaming surface: `invoke()` is sync-shaped (`str` return). Should it
+    return `AsyncIterator[Event]` instead? Likely yes; deferred until a
+    consumer needs streaming (the CLI doesn't yet).
+  - Cancellation / interrupt: no method today; LangGraph and Pi both
+    support it natively. Add when needed.
+  - Memory wiring: today each adapter wires its own memory (DeepAgents
+    via `InMemorySaver`, MSAF via prepend). After `MemoryManager` lands,
+    adapters consume from it; the interface should declare a `memory`
+    constructor parameter.
+
+---
+
+### `Extension` protocol
+
+- **Code:** `src/assistant/extensions/base.py:15`
+- **Stability:** **Provisional** (with a known deprecation path)
+- **Providers:**
+  - Empty-tool stubs for `ms_graph`, `teams`, `sharepoint`, `outlook`,
+    `gmail`, `gcal`, `gdrive` (`src/assistant/extensions/`)
+  - Real MS extensions arrive in `ms-graph-extension` phase (P5)
+  - Real Google extensions arrive in `google-extensions` phase
+- **Conformance suite:** not yet — extension health checks are
+  per-extension. A `tests/conformance/test_extension.py` covering
+  `name`, `health_check()`, and the future `register()` is owed.
+- **Known leaks (load-bearing):**
+  - **Dual-surface methods** `as_langchain_tools()` and
+    `as_ms_agent_tools()` (`base.py:19-21`) bake consumer identity into
+    the protocol. Adding a Pi consumer requires either a third method
+    (`as_pi_tools()`) or a refactor. Refactor is the right move: replace
+    with `register(registry: CapabilityRegistry, persona: PersonaConfig)`
+    once `CapabilityRegistry` exists. This is the cleanest example in the
+    repo of a leaked interface.
+- **Open questions:**
+  - What does `register()` accept exactly? OpenAPI specs? Pure JSON
+    Schema + handler references that the registry wraps into OpenAPI?
+    Both? Resolution comes with the `CapabilityRegistry` design.
+  - Should extensions declare their persona-affinity (e.g. "this
+    extension is only for `work`") at the protocol level, or via
+    persona-side config? Lean toward the latter to keep the protocol
+    persona-agnostic.
+
+---
+
+### `CapabilityRegistry` (proposed)
+
+- **Code:** not yet — partial precursor in `HttpToolRegistry` (HTTP +
+  OpenAPI discovery from persona `tool_sources`)
+- **Stability:** **Pre-interface**
+- **Providers:**
+  - `HttpToolRegistry` — partial implementation, current; four open
+    follow-ups (#16–#19 in archived `http-tools-layer`)
+  - Self-hosted MCP gateway — planned projection target
+  - CLI projection (`assistant tool …`) — planned
+  - AgentCore Gateway — slot-compatible if the canonical form is
+    OpenAPI-compatible
+- **Conformance suite:** not yet — design first.
+- **Known leaks (design-time):**
+  - OpenAPI 3.x as the canonical form is the right baseline but needs
+    extensions: streaming/progress (`x-aa-streaming`), persona/role
+    scoping (`x-aa-roles`), per-projection auth policy
+    (`x-aa-auth.<projection>`). Define these as a vendor extension
+    namespace before any extension publishes specs.
+  - "Tool" vs "skill" vs "agent" — all three are capabilities at the
+    registry level but they are not the same thing. The registry needs
+    a `kind` field and the discovery API needs to filter by it.
+- **Open questions:**
+  - In-process vs out-of-process: is the registry a Python object the
+    harness imports, or a service the harness queries over HTTP/MCP?
+    Both, with the same canonical form — in-process for fast path,
+    out-of-process for cross-runtime.
+  - Authority for `GuardrailProvider.authorize(persona, role, capability,
+    projection)`: does the registry call out to a separate provider, or
+    is authorization baked into discovery results? Lean toward the
+    former for clean separation.
+  - Hot-add semantics: when an extension publishes a new capability,
+    when is it visible to existing sessions? Next turn, or next session?
+    Per-projection answer (MCP supports notifications; HTTP can poll).
+
+---
+
+### `MemoryManager` (proposed)
+
+- **Code:** not yet — `MemoryPolicy` exists in MSAF stub
+  (`harnesses/sdk/ms_agent_fw.py` D27 minimal-prepend) but is a workaround
+  pattern, not the eventual interface
+- **Stability:** **Pre-interface**
+- **Providers:**
+  - Local Postgres + Graphiti — planned in `memory-architecture` phase
+  - Letta self-host — candidate
+  - Zep self-host — candidate
+  - LangGraph `PostgresStore` — could back the local provider directly
+  - AgentCore Memory — managed slot once the work persona lands (P15)
+  - Foundry Memory — managed alternative for Azure-bound work persona
+- **Conformance suite:** not yet — design first.
+- **Known leaks (design-time):**
+  - The MSAF "minimal-prepend" pattern (D27) treats memory as a
+    read-only context source. The full interface must support
+    write-through and async ingestion; the minimal-prepend pattern is
+    fine as a read implementation but must not constrain the interface
+    shape.
+  - Per-persona DB isolation is a hard constraint (CLAUDE.md): the
+    interface must make cross-persona reads physically impossible.
+    Concretely: `MemoryManager.__init__(persona: PersonaConfig)` binds
+    to that persona; there is no `manager.get(persona=other, ...)`
+    method. The privacy guard
+    (`tests/_privacy_guard_plugin.py`) enforces this at the test layer.
+- **Open questions:**
+  - Distinction between session memory (this conversation) and
+    long-term memory (across conversations). AgentCore models them as
+    one service; Letta separates them; LangGraph treats checkpointers
+    and stores as distinct. Decision: separate primitives
+    (`SessionStore` vs `MemoryManager`) because their access patterns
+    differ enough to warrant distinct interfaces.
+  - Write-through vs async ingestion: Graphiti entity extraction is too
+    slow for the hot path. Architecture: write to a fast log (Postgres
+    table, or the harness's session store) synchronously; async
+    pipeline distills into the persona's graph. The interface should
+    expose both `ingest(events, sync=True|False)` and let providers
+    decide which is supported.
+  - Forgetting: GDPR-shaped delete requests. Required for `personal`;
+    likely required for `work` under employer policy. Define
+    `MemoryManager.forget(query)` with provider-specific semantics.
+
+---
+
+### `IdentityProvider` (proposed)
+
+- **Code:** not yet — `bao-vault` skill exists for OpenBao operations
+  but no agent-facing interface
+- **Stability:** **Pre-interface**
+- **Providers:**
+  - OpenBao / HashiCorp Vault self-host — primary local provider
+  - AgentCore Identity — managed, for `work` if employer is AWS
+  - Azure Managed Identity — managed, for `work` if employer is Azure
+  - AWS IAM / Workload Identity Federation — for non-AgentCore AWS
+- **Conformance suite:** not yet.
+- **Known leaks (design-time):**
+  - Two concerns are conflated in the name "identity": (a) credentials
+    the agent uses to call third-party APIs (OAuth tokens, API keys),
+    (b) the agent's own workload identity for service-to-service auth.
+    AgentCore Identity handles both; OpenBao primarily handles (a) via
+    secret storage. The interface must distinguish these or providers
+    won't slot.
+  - Per-projection auth interacts with this: the `CapabilityRegistry`
+    needs an `IdentityProvider` to resolve credentials when projecting
+    a tool over HTTP that requires OAuth.
+- **Open questions:**
+  - Token refresh: managed providers handle it transparently; OpenBao
+    requires explicit refresh logic. Should the interface paper over
+    this, or expose it as a capability?
+  - Audit trail: managed providers emit audit events; local Vault
+    requires the caller to log. Surface as a capability.
+
+---
+
+### `SessionStore` (proposed)
+
+- **Code:** not yet — LangGraph `InMemorySaver` used directly in
+  `harnesses/sdk/deep_agents.py:60`
+- **Stability:** **Pre-interface**
+- **Providers:**
+  - LangGraph `InMemorySaver`, `SqliteSaver`, `PostgresSaver`
+  - Pi `SessionManager` (JSON-L) — interesting because it survives
+    process restarts trivially
+  - AgentCore session state — managed
+  - OpenAI Threads — managed
+- **Conformance suite:** not yet.
+- **Known leaks (design-time):**
+  - LangGraph's `thread_id` is a session-identity concept that not all
+    providers expose. The interface should use an opaque `SessionId`
+    type and let providers map.
+  - Forking and branching: Pi has it natively; LangGraph supports
+    time-travel; managed providers vary. Surface as a capability, not
+    a required method.
+- **Open questions:**
+  - Lift this primitive now (force the design with one provider) or
+    wait until a second harness needs the same checkpoint behaviour?
+    Lean toward lift-on-second-consumer to avoid premature abstraction.
+  - Relationship to `MemoryManager`: session writes feed memory
+    ingestion. Define the write hook so memory ingestion can subscribe
+    to session writes without each harness re-implementing the bridge.
+
+---
+
+### `Sandbox` (proposed)
+
+- **Code:** not yet — Pi has built-in `bash`; DeepAgents has no sandbox
+- **Stability:** **Pre-interface**
+- **Providers:**
+  - Local Docker — primary local provider for code execution
+  - Playwright self-host — for browser
+  - e2b.dev self-host — alternative code sandbox
+  - AgentCore Code Interpreter, AgentCore Browser — managed
+  - OpenAI Code Interpreter — managed
+- **Conformance suite:** not yet.
+- **Known leaks:**
+  - Code execution and browsing have legitimately different surfaces
+    (file I/O semantics, network policy, output shapes). Splitting into
+    `CodeSandbox` and `BrowserSandbox` is likely correct; deferred until
+    a real cross-provider need exists.
+- **Open questions:**
+  - Resource limits as a capability: providers vary widely. Worth
+    surfacing as part of the binding configuration so persona-side
+    policy can constrain.
+
+---
+
+### `AgentRegistry` (proposed)
+
+- **Code:** not yet — current spawn lives in `HarnessAdapter` as
+  `spawn_sub_agent` (`harnesses/base.py:39`)
+- **Stability:** **Pre-interface**
+- **Providers:**
+  - In-process Python registry — fast path for same-runtime spawning
+  - A2A protocol — open standard for cross-process / cross-runtime
+  - AgentCore Runtime invocations — managed cross-runtime path
+- **Conformance suite:** not yet.
+- **Known leaks (design-time):**
+  - The current `spawn_sub_agent` constructs a same-type child harness
+    (`DeepAgentsHarness(self.persona, role)` in `deep_agents.py:92`).
+    This prevents cross-harness delegation (e.g., `personal` running
+    DeepAgents delegating an MS-Graph subtask to MSAF). The registry
+    must support cross-harness spawning explicitly.
+- **Open questions:**
+  - Routing policy: when a role asks to spawn, who decides which harness
+    serves the child? Static (role declares preferred harness),
+    dynamic (registry picks based on capability requirements), or
+    hybrid? Hybrid is likely correct — role declares constraints,
+    registry resolves.
+  - Concurrency model: in-process spawns are tasks; A2A spawns are
+    remote calls. The handle type returned must abstract over both.
+
+---
+
+### Observability (OpenTelemetry gen-ai)
+
+- **Code:** `src/assistant/telemetry/` (Langfuse-backed); see also
+  `docs/observability.md`
+- **Stability:** **Provisional** (closest to Stable of any interface
+  here — well-shaped, opt-in, real provider)
+- **Providers:**
+  - Langfuse self-hosted (current, default for `LANGFUSE_ENABLED=true`)
+  - Noop provider (current, default)
+  - Phoenix, Jaeger, Honeycomb — slot-compatible via OTel
+  - AgentCore Observability, Datadog — slot-compatible via OTel
+- **Conformance suite:** test coverage exists for the Langfuse provider
+  (`tests/telemetry/`); cross-provider conformance is implicit via
+  OTel itself. Adding a `tests/conformance/test_tracer.py` is a small
+  next step.
+- **Known leaks:** Graphiti queries are intentionally traced at the
+  `MemoryManager` boundary, not at the Graphiti client layer, to avoid
+  double-counting (`docs/observability.md`). This is correct, but it
+  means the OTel attribute conventions for memory operations are
+  repo-specific until the OTel gen-ai spec covers memory operations
+  formally.
+- **Open questions:**
+  - Span attribute conventions for persona/role: not standardized.
+    The repo uses `assistant.persona` and `assistant.role` (see
+    `set_assistant_ctx` in `cli.py:223`). Either align with an emerging
+    convention or document the choice as a repo-specific dialect.
+
+---
+
+### `SkillResolver` (deferred)
+
+- **Code:** not yet — `.agents/skills/` consumed directly via filesystem
+  walker; `agentic-coding-tools/skills/install.sh` is the upstream sync
+- **Stability:** **Pre-interface**
+- **Providers:**
+  - Filesystem walker — current behaviour
+  - Pi's skill discovery — natively reads the same directories; no
+    adapter needed
+- **Conformance suite:** not yet — interface not yet defined.
+- **Why deferred:** the static-file approach works today. The
+  interface lifts when (a) skills need to be loaded dynamically per
+  turn based on a query, (b) skill matching needs to be policy-gated
+  per role, or (c) a second discovery source materializes (e.g.,
+  fetching skills from a registry).
+- **Open questions:** none yet — design lives in the future.
+
+## How entries change state
+
+A change to any entry follows the same pattern:
+
+1. A PR proposes the change (new entry, stability bump, leak added,
+   conformance test landed).
+2. The PR also touches `primitives-and-providers.md` if the row in
+   that document needs updating (e.g., a new provider entered the
+   matrix).
+3. A leak being **discovered** does not by itself demote stability;
+   a leak being **load-bearing** (consumers depending on it) does.
+4. Stability promotions require the conformance suite. A primitive
+   cannot graduate Experimental → Provisional without a conformance
+   harness, even if a second provider exists.
+5. Managed-provider claims of conformance require a periodic
+   verification job (see "Conformance against managed providers"
+   above). Mock-only conformance caps a provider at Provisional.
+
+## Ledger drift mitigation
+
+The ledger's value collapses to zero if entries lag the code. Two
+mitigations, in increasing strength:
+
+1. **Reviewer obligation (current):** any PR that modifies
+   `src/assistant/harnesses/`, `src/assistant/extensions/`,
+   `src/assistant/core/memory*` (when added),
+   `src/assistant/telemetry/`, or related interface files must touch
+   the corresponding ledger entry. Reviewers reject PRs that don't.
+2. **CI gate (planned):** a check that fails the build when an
+   interface-bearing file is modified without a corresponding
+   ledger touch. Implementation deferred; the obligation in (1) is
+   the working agreement until the gate lands.
+
+The ledger is meant to be edited frequently. A stale entry is worse
+than a missing one — it silently lies to consumers about what they
+can depend on.
+
+## Open meta-questions
+
+Questions about the ledger itself rather than any specific entry:
+
+- Should this document live in `docs/architecture/` or in
+  `openspec/specs/`? OpenSpec handles requirement-shaped artifacts
+  well, but interface stability is more of a continuously-maintained
+  ledger than a delta. Current call: docs/architecture/, with OpenSpec
+  changes referencing entries by name.
+- Frequency of review: every PR that touches a primitive should
+  consider whether the ledger entry needs updating. A quarterly
+  consolidation pass keeps the ledger honest.
+- Cross-link to the gotchas document: gotchas often surface from
+  ledger entries (e.g., G6 is a privacy-boundary gotcha that connects
+  to `MemoryManager` design). Reciprocal links from each gotcha to
+  the relevant primitive are owed.

--- a/docs/architecture/interface-stability.md
+++ b/docs/architecture/interface-stability.md
@@ -60,7 +60,8 @@ two-tier conformance regime:
 
 - **Local conformance** — runs against real providers in CI on every
   PR. Local providers (Ollama, LangGraph checkpointers, OpenBao,
-  self-hosted Langfuse) are the conformance baseline.
+  self-hosted Langfuse, local Postgres + Graphiti) are the conformance
+  baseline.
 - **Managed conformance** — runs in two modes: against mocks of the
   managed provider in CI on every PR, and against the real managed
   provider in a periodic verification job (cadence per provider,
@@ -71,6 +72,15 @@ A provider's stability classification depends on which tier it can
 satisfy. A managed provider cannot reach **Stable** without an active,
 green periodic verification job. A managed provider's mock conformance
 can support **Provisional** but does not on its own justify higher.
+
+Conformance is always **per-deployment** (per bound persona), not
+multi-tenant. A provider proves it satisfies the interface for one
+persona at a time. This is a direct consequence of git-as-multi-tenancy
+(see `primitives-and-providers.md` → "What's actually novel"):
+multi-tenant scenarios are not part of the contract, because two
+personas never share a process. Cross-deployment behaviour
+(e.g. one persona delegating to another) is an A2A protocol concern,
+not a provider conformance concern.
 
 ## Cross-primitive constraints
 
@@ -190,14 +200,23 @@ Each entry below follows the same template:
 
 ### `CapabilityRegistry` (proposed)
 
-- **Code:** not yet — partial precursor in `HttpToolRegistry` (HTTP +
-  OpenAPI discovery from persona `tool_sources`)
-- **Stability:** **Pre-interface**
+- **Code:** not yet as a unified primitive; substantial precursor
+  exists as `HttpToolRegistry` from archived P3 http-tools-layer
+  (HTTP + OpenAPI discovery, `$ref` resolution, auth handling,
+  registry pattern, `--list-tools` CLI flag). `ToolPolicy` protocol
+  exists from P1.8 capability-protocols.
+- **Stability:** **Experimental** (precursor real and shipping;
+  lifting to a unified primitive with multiple projections is the
+  proposed `capability-registry` phase)
 - **Providers:**
   - `HttpToolRegistry` — partial implementation, current; four open
     follow-ups (#16–#19 in archived `http-tools-layer`)
+  - Extensions exposed via `as_langchain_tools()` /
+    `as_ms_agent_tools()` — current dual-surface pattern to be
+    replaced
   - Self-hosted MCP gateway — planned projection target
-  - CLI projection (`assistant tool …`) — planned
+  - CLI projection (`assistant tool …`) — partial today via
+    `--list-tools`
   - AgentCore Gateway — slot-compatible if the canonical form is
     OpenAPI-compatible
 - **Conformance suite:** not yet — design first.
@@ -225,45 +244,63 @@ Each entry below follows the same template:
 
 ---
 
-### `MemoryManager` (proposed)
+### `MemoryManager`
 
-- **Code:** not yet — `MemoryPolicy` exists in MSAF stub
-  (`harnesses/sdk/ms_agent_fw.py` D27 minimal-prepend) but is a workaround
-  pattern, not the eventual interface
-- **Stability:** **Pre-interface**
+- **Code:** `src/assistant/core/memory.py:20` (real, archived P2
+  memory-architecture); `MemoryPolicy` protocol in
+  `src/assistant/core/capabilities/` (real, archived P1.8
+  capability-protocols)
+- **Stability:** **Experimental** (real implementation exists; interface
+  shape has known load-bearing leaks; conformance suite not yet
+  written)
 - **Providers:**
-  - Local Postgres + Graphiti — planned in `memory-architecture` phase
-  - Letta self-host — candidate
-  - Zep self-host — candidate
+  - Postgres + Graphiti via `MemoryManager` (current);
+    `PostgresGraphitiMemoryPolicy` auto-selected when `database_url`
+    configured
+  - Letta self-host, Zep self-host, mem0 self-host — candidates
   - LangGraph `PostgresStore` — could back the local provider directly
-  - AgentCore Memory — managed slot once the work persona lands (P15)
+  - AgentCore Memory — managed slot once work persona lands (P15)
   - Foundry Memory — managed alternative for Azure-bound work persona
-- **Conformance suite:** not yet — design first.
-- **Known leaks (design-time):**
+- **Conformance suite:** not yet — `MemoryPolicy` has tests but no
+  cross-provider conformance harness exists. Required before lifting
+  to Provisional.
+- **Known leaks (load-bearing):**
+  - **Persona parameter on methods.** `get_context(persona, role, …)`,
+    `store_fact(persona, key, value)`, `store_interaction(persona, …)`,
+    and similar methods accept a `persona: str` parameter
+    (`memory.py:30, 65, etc.`). Under git-as-multi-tenancy this is
+    leakage — each instance is already persona-bound at construction
+    via the `session_factory`; the method parameter is a relic of a
+    multi-tenant assumption that doesn't apply (see
+    `primitives-and-providers.md` → "Privacy boundary"). Cleanup
+    folds into the `binding-manifest` phase: drop the parameter, the
+    instance is the persona's manager.
   - The MSAF "minimal-prepend" pattern (D27) treats memory as a
-    read-only context source. The full interface must support
+    read-only context source. The full interface supports
     write-through and async ingestion; the minimal-prepend pattern is
-    fine as a read implementation but must not constrain the interface
-    shape.
-  - Per-persona DB isolation is a hard constraint (CLAUDE.md): the
-    interface must make cross-persona reads physically impossible.
-    Concretely: `MemoryManager.__init__(persona: PersonaConfig)` binds
-    to that persona; there is no `manager.get(persona=other, ...)`
-    method. The privacy guard
-    (`tests/_privacy_guard_plugin.py`) enforces this at the test layer.
+    fine as a read implementation but must not constrain the
+    interface shape.
+- **Semantic conformance points (currently unspecified — gaps):**
+  - What does `get_context()` guarantee about freshness? Are writes
+    from the same turn visible to subsequent `get_context()` calls?
+    Not specified.
+  - What does `store_fact()` guarantee about durability — is the call
+    durable on return, or only after `session.commit()`? Implementation
+    commits, but not documented in the interface.
+  - Cross-thread / cross-process visibility within the same persona
+    (e.g. scheduler writes + REPL reads): not specified.
 - **Open questions:**
   - Distinction between session memory (this conversation) and
-    long-term memory (across conversations). AgentCore models them as
-    one service; Letta separates them; LangGraph treats checkpointers
-    and stores as distinct. Decision: separate primitives
-    (`SessionStore` vs `MemoryManager`) because their access patterns
-    differ enough to warrant distinct interfaces.
-  - Write-through vs async ingestion: Graphiti entity extraction is too
-    slow for the hot path. Architecture: write to a fast log (Postgres
-    table, or the harness's session store) synchronously; async
-    pipeline distills into the persona's graph. The interface should
-    expose both `ingest(events, sync=True|False)` and let providers
-    decide which is supported.
+    long-term memory (across conversations). AgentCore models them
+    as one service; Letta separates them; LangGraph treats
+    checkpointers and stores as distinct. Current code couples them
+    via `MemoryManager`; the binding-manifest phase should consider
+    splitting `SessionStore` out.
+  - Write-through vs async ingestion: Graphiti entity extraction is
+    too slow for the hot path. Architecture: write to a fast log
+    (Postgres `memory` table) synchronously; async pipeline distills
+    into the persona's graph. Currently both happen synchronously;
+    needs async pipeline for scale.
   - Forgetting: GDPR-shaped delete requests. Required for `personal`;
     likely required for `work` under employer policy. Define
     `MemoryManager.forget(query)` with provider-specific semantics.

--- a/docs/architecture/primitives-and-providers.md
+++ b/docs/architecture/primitives-and-providers.md
@@ -1,0 +1,328 @@
+# Primitives and Providers
+
+This document is the architectural statement of `agentic-assistant`. It names
+the agent-platform **primitives** the repo abstracts over, the **interfaces**
+those primitives present, and the **providers** (local reference
+implementations, third-party open-source projects, and managed services) that
+can be plugged in behind each interface on a per-persona basis.
+
+The single sentence: **the repo's value is not any one implementation; it is
+the persona-scoped composition of selected providers behind stable interfaces,
+with a privacy boundary between personas.**
+
+## Architectural framing
+
+This is the Service Provider Interface (SPI) pattern applied to agent
+primitives. The same pattern shows up across software history:
+
+- **JDBC / Python DB-API** — interface over relational databases; drivers per
+  vendor; conformance test kits ensure swap-ability.
+- **Kubernetes CRI/CNI/CSI** — interfaces over container runtime, networking,
+  and storage; operators pick providers per cluster.
+- **SQLAlchemy dialects** — one ORM surface, N database backends.
+- **Terraform providers** — one config language, N cloud and SaaS targets.
+- **OpenTelemetry exporters** — one instrumentation surface, N backends.
+
+The pattern earns its keep when three disciplines are honoured: interfaces
+stay narrow (every method is a coupling point), conformance tests verify
+that any implementation satisfies the contract, and feature matrices
+acknowledge legitimate per-provider divergence without polluting the core
+interface.
+
+A **persona** in this repo is a configuration bundle — which model, which
+harness, which memory backend, which identity store, which tool catalog, which
+observability backend — bound together with a private config repo (mounted as
+a submodule under `personas/<name>/`) and its own database. A **role** is a
+behavioural overlay (prompt, delegation rules, preferred tools) that runs
+on top of whatever provider mix the persona selects.
+
+### What's actually novel
+
+Narrowed honestly: the load-bearing novelty in this repo is not the
+persona-and-role concept itself (multi-tenant agent platforms achieve
+analogous boundaries; role-as-system-prompt-fragment is well-explored).
+The unprecedented combination is:
+
+- **Public code, private config via per-persona git submodules.** The
+  public repo can ship open-source while every persona's credentials,
+  role overrides, DB schema, and skill set live in independent private
+  submodules under `personas/<name>/`. No managed agent platform offers
+  this split because they assume cloud-hosted tenant isolation; no
+  open-source framework offers it because they assume a single user.
+- **A two-layer privacy guard** (`tests/_privacy_guard_plugin.py` plus
+  `tests/conftest.py`) that enforces the public/private split at test
+  collection time (substring scan for private-persona identifiers) and
+  at runtime (FS I/O patching against private paths). This is the
+  artifact that turns the submodule split from convention into
+  contract.
+
+Persona-as-execution-boundary, role-as-overlay, and SPI-shaped provider
+selection are the *delivery vehicle* for that novelty. They are not the
+novelty themselves; they are well-trodden patterns adapted to carry
+the privacy boundary cleanly.
+
+## The primitive table
+
+Each row is a primitive. Each row defines an **interface** (the abstract
+contract the repo owns), names current and prospective **providers** for it,
+and notes whether the interface is currently realized in code, planned, or
+still under design. Stability classification per interface lives in
+[`interface-stability.md`](./interface-stability.md).
+
+| Primitive | Interface (repo-owned contract) | Local / OSS providers | Managed providers |
+|---|---|---|---|
+| **Models** (LLMs) | `ChatModel` — init, invoke, stream, tool-calling, vision, thinking budget | Ollama, vLLM, llama.cpp; LiteLLM or Pi-ai as cross-provider façades | Anthropic, OpenAI, Google, Bedrock, Vertex, Azure OpenAI, xAI, Groq, Fireworks, Together |
+| **Harness / Framework** | `HarnessAdapter` (`src/assistant/harnesses/base.py:12`); SDK and Host tiers | DeepAgents/LangGraph (implemented), MSAF (stub → P5), Pi (proposed), Strands, ADK, OpenAI Agents SDK, CrewAI, AutoGen | AgentCore Runtime, Bedrock Agents, OpenAI Assistants, Azure AI Foundry Agents, Vertex Agent Builder, Anthropic managed agents (when shipped) |
+| **Capability Registry** | `CapabilityRegistry` (proposed) — publish, discover, project; OpenAPI canonical form with streaming and scoping extensions | `HttpToolRegistry` (current, partial); self-hosted MCP gateway projecting OpenAPI; CLI projection | AgentCore Gateway, OpenAI Tools, Azure Foundry Connectors |
+| **Memory** | `MemoryManager` (proposed) — read by query, ingest event, semantic search, forget, per-persona isolation | Postgres + Graphiti (planned), Letta, Zep self-host, mem0 self-host, Cognee, LangGraph `PostgresStore` | AgentCore Memory, OpenAI Threads/Memory, Foundry Memory, Anthropic memory primitives (when shipped) |
+| **Identity** | `IdentityProvider` (proposed) — credential vault for agent-to-tool/agent-to-service auth, workload identity | OpenBao / HashiCorp Vault (`bao-vault` skill); local OAuth flows | AgentCore Identity, Azure Managed Identity, AWS IAM, Workload Identity Federation, OpenAI service accounts |
+| **Sessions / Checkpointing** | `SessionStore` (proposed) — persist conversation state, fork, branch, resume | LangGraph `InMemorySaver` (current), `SqliteSaver`, `PostgresSaver`, Pi `SessionManager` (JSON-L) | AgentCore session state, OpenAI Threads, Foundry runs |
+| **Observability** | OpenTelemetry gen-ai semantic conventions; thin `Tracer` wrapper at boundaries | Langfuse self-hosted (current, see [`observability.md`](../observability.md)), Phoenix, Jaeger | AgentCore Observability, Datadog, Honeycomb, LangSmith |
+| **Sandboxes** (code, browser) | `Sandbox` (proposed) — bounded execution surface, capability-gated | Docker + Playwright, e2b.dev self-host, Pi built-in `bash` | AgentCore Code Interpreter, AgentCore Browser, OpenAI Code Interpreter, e2b.dev managed |
+| **Agent Registry** | `AgentRegistry.spawn(...)` (proposed) — local in-process fast path; A2A for cross-process / cross-runtime | In-process Python registry; A2A bridge for cross-runtime | AgentCore Runtime invocations, OpenAI Assistants handoffs, Foundry agent orchestration |
+| **Skill discovery** | `SkillResolver` (proposed) — given query, return matching skills; consume `~/.agents/skills/` and `.agents/skills/` layouts | In-repo skill walker (synced from `agentic-coding-tools/skills/`); Pi's native skill discovery | (No managed equivalent today) |
+
+The repo holds the interface column. Providers in the local/OSS column are
+either implemented, planned, or candidates the repo is positioned to adopt
+without core changes. Providers in the managed column are slot-compatible
+once interface adapters exist; they are not preconditions for the local
+column to be useful.
+
+## Example persona compositions
+
+The provider selection is per-persona, not global. Two illustrative
+compositions:
+
+### `personal` persona — local-first, sovereign
+
+| Primitive | Provider |
+|---|---|
+| Models | Claude via Anthropic API; Ollama for offline fallback |
+| Harness | DeepAgents (LangGraph) for general reasoning; Pi for code/file/shell tasks (post-integration) |
+| Capability Registry | Self-hosted MCP gateway over the repo's HTTP+OpenAPI tool registry |
+| Memory | Local Postgres + Graphiti, scoped to `personas/personal/` DB |
+| Identity | OpenBao vault holding personal API keys |
+| Sessions | LangGraph `PostgresSaver` against persona-local Postgres |
+| Observability | Self-hosted Langfuse (per `docs/observability.md`) |
+| Sandboxes | Local Docker for code execution; Playwright for browser |
+| Agent Registry | In-process Python registry |
+| Skill discovery | Repo `.agents/skills/` synced from `agentic-coding-tools` |
+
+### `work` persona — employer-cloud, leverage managed services
+
+| Primitive | Provider |
+|---|---|
+| Models | Whichever frontier models the employer licenses (Claude / GPT / Gemini via Bedrock / Azure / Vertex) |
+| Harness | MSAF for M365-shaped work; AgentCore Runtime for serverless agents |
+| Capability Registry | AgentCore Gateway federating internal APIs and employer SaaS |
+| Memory | AgentCore Memory (or Foundry Memory on Azure shops) |
+| Identity | AgentCore Identity bridged to employer SSO / Azure Managed Identity |
+| Sessions | AgentCore session state |
+| Observability | AgentCore Observability → employer APM (Datadog / Splunk / etc.) |
+| Sandboxes | AgentCore Code Interpreter, AgentCore Browser |
+| Agent Registry | AgentCore Runtime + A2A for cross-process spawning |
+| Skill discovery | Same as `personal` (skills are persona-portable) |
+
+The role catalog (`roles/researcher`, `roles/triage`, `roles/coder`, etc.),
+the persona × role prompt composition (`src/assistant/core/composition.py`),
+the privacy guard (`tests/_privacy_guard_plugin.py`), the OpenSpec workflow,
+and the skill discovery layer are **identical across both personas**. Only
+the provider bindings differ.
+
+## What's filled today vs. aspirational
+
+Honest accounting of the matrix as of writing:
+
+**Interfaces realized in code:**
+
+- `HarnessAdapter` and its two tiers (`harnesses/base.py:12,24,48`) — narrow,
+  but a planned shrink is expected once `AgentRegistry` and
+  `CapabilityRegistry` land (sub-agent spawning and tool wiring move out of
+  the adapter).
+- `Extension` protocol (`extensions/base.py:15`) — currently leaky: the
+  `as_langchain_tools()` / `as_ms_agent_tools()` dual-surface bakes consumer
+  identity into the protocol. Slated for replacement by a
+  `register(registry, persona)` shape once `CapabilityRegistry` exists.
+- HTTP tool registry (`HttpToolRegistry` + OpenAPI discovery from persona
+  `tool_sources`) — partial implementation of the future
+  `CapabilityRegistry`. Four open follow-ups (#16–#19) address known gaps.
+- Observability — fully real via Langfuse with OTel-shaped spans, opt-in.
+
+**Interfaces planned but not yet defined:**
+
+- `CapabilityRegistry` (canonical form + projections) — design work pending.
+- `MemoryManager` — interface shape sketched (read/ingest/search/forget);
+  Postgres + Graphiti provider planned for the `memory-architecture` phase.
+- `IdentityProvider` — OpenBao integration exists at the script level
+  (`bao-vault` skill) but no agent-facing interface yet.
+- `SessionStore` — LangGraph checkpointers are used directly by the
+  DeepAgents adapter; lift to a primitive once a second harness needs the
+  same capability.
+- `Sandbox` — currently per-harness (Pi has `bash` built in; DeepAgents has
+  none yet). Lift when sandbox use becomes cross-harness.
+- `AgentRegistry` — implicit in `spawn_sub_agent` today; should be lifted
+  out of `HarnessAdapter`.
+
+**Interfaces deferred:**
+
+- `SkillResolver` — `.agents/skills/` layout is stable and consumed
+  directly today; formal interface waits until dynamic skill loading per
+  turn matters.
+
+## Cross-cutting concerns the matrix hides
+
+The primitive table draws clean per-row separations. Real systems have
+wiring between rows, and these cross-cuts are where SPI patterns
+classically leak. Naming the cross-cuts explicitly here so they are
+not rediscovered per integration:
+
+- **Event-schema agreement** between `HarnessAdapter` (emits) and
+  `MemoryManager` (consumes). The two interfaces share a vocabulary —
+  user message, assistant message, tool call, tool result, plan delta —
+  that neither interface "owns." A normalized event envelope must live
+  at the architecture level, not inside any one provider.
+- **Span propagation** across `HarnessAdapter` → `CapabilityRegistry` →
+  `IdentityProvider` → external API. OTel context propagation
+  conventions must be shared and enforced; otherwise traces fracture
+  at the first cross-primitive boundary.
+- **Identity reference vocabulary.** When `CapabilityRegistry` projects
+  an HTTP tool that requires OAuth, the projection layer must call
+  `IdentityProvider` with a stable identifier for "which credential
+  for this persona/role/projection." That identifier is shared
+  vocabulary; both primitives must agree on its shape.
+- **Session ↔ memory write hook.** `SessionStore` writes feed
+  `MemoryManager` ingestion. Each harness must not re-implement the
+  bridge; define the hook once.
+- **Compatibility groups.** Some role requirements span multiple
+  primitives (e.g. `interrupt_resume` needs harness support + session
+  checkpoint support + memory replay safety). The capability matrix
+  is per-interface; the binding validator must express constraints
+  *across* interfaces or it cannot reject incompatible provider mixes
+  at startup. This is the largest known gap in the current design and
+  is the most likely place a future role exposes a real bug.
+
+These cross-cuts are not new primitives. They are conventions that
+several primitives must agree on. They live in this document and the
+stability ledger; they do not get their own interface.
+
+## Role portability — with caveats
+
+The doc's strongest claim — that role definitions are persona-portable —
+holds at the prompt and tool catalog layers but **not unconditionally
+at the execution layer**. The same role YAML produces:
+
+- **Identical prompts** on any binding (composition is provider-agnostic).
+- **Identical tool catalogs** when the bound capability registry has the
+  required capabilities (matrix check at startup).
+- **Divergent execution semantics** for advanced features. A role with
+  `delegation.allowed_sub_roles` spawns via graph nodes on LangGraph,
+  via handoffs on MSAF, via extension-built routing on Pi. The *outcome*
+  is similar in shape; the *guarantees* differ (graph spawn can run in
+  parallel; handoff is sequential by default).
+
+Portability discipline: roles declare their required capabilities
+explicitly; the binding validator rejects persona configurations whose
+provider mix cannot supply them; provider-specific behaviour is opt-in
+via capability declarations, never silent.
+
+## Binding-shaped vs migration-shaped primitives
+
+Not every provider swap is a config change. Distinguishing:
+
+- **Swap-shaped** (binding is config; the change is hot or near-hot):
+  Models (no state), Observability (sinks accept arbitrary streams),
+  Sandboxes (per-invocation, stateless from the architecture's view),
+  Capability Registry (provider catalogs can be merged or swapped),
+  Skill discovery (filesystem is filesystem).
+- **Migration-shaped** (binding implies a deployment event; data or
+  state must move): Memory (long-term storage of facts, entities,
+  timelines), Sessions (resumable conversation state), Identity
+  (tokens and credentials must be re-issued in the new vault).
+- **Borderline** (mostly swap, with state in some implementations):
+  Harness / Framework — runtime is stateless per-session, but bound
+  sessions in flight don't survive a swap mid-session.
+
+Treat migration-shaped primitives accordingly in operational planning:
+they need a migration runbook per provider pair, not a config diff.
+
+This pattern only delivers on its promise if three disciplines are followed:
+
+1. **Conformance test suites per primitive.** Every interface has a test
+   suite (`tests/conformance/test_<primitive>.py`) that any provider
+   implementation must pass. JDBC has a TCK; Python's DB-API has a smaller
+   one; this repo needs its own. Without conformance tests, the interface
+   becomes documentation rather than a contract. The existing privacy guard
+   (`tests/_privacy_guard_plugin.py`) is a precedent for cross-implementation
+   conformance enforcement.
+
+2. **Capability matrices, not feature parity.** Providers will diverge on
+   advanced features (semantic search support, interrupt/resume, streaming
+   shape, multi-modal input). Don't force the interface to the lowest
+   common denominator. Each provider advertises capabilities
+   (`MemoryManager.supports("semantic_search")`,
+   `HarnessAdapter.supports("interrupt_resume")`); roles declare
+   requirements; the persona's binding is rejected at startup if a required
+   capability isn't supplied by its chosen providers.
+
+3. **Narrow interfaces.** Each method on an SPI is a permanent coupling
+   point. Before adding a method, ask whether it could be a capability on
+   an existing method, a method on a different primitive, or pushed into a
+   provider as a non-portable extension. The `Extension` protocol's
+   dual-surface methods are an example of what *not* to do: they encoded
+   consumer identity into the protocol and now have to be unwound.
+
+## Privacy boundary
+
+The persona-as-sovereign-execution-boundary claim is not aspirational — it
+is enforced at three layers and must be preserved by any new provider
+binding:
+
+- **Code layer:** persona-specific config lives in private submodules under
+  `personas/<name>/`; the public repo never imports from them, only from
+  fixture copies under `tests/fixtures/personas/`.
+- **Data layer:** each persona has its own database; the `MemoryManager`
+  interface must make cross-persona reads physically impossible (instances
+  bind to a `PersonaConfig` at construction; there is no `manager.get(
+  persona=other, ...)`).
+- **Test layer:** the two-layer privacy guard
+  (`tests/conftest.py` + `tests/_privacy_guard_plugin.py`) enforces at
+  collection time (substring scan for private-persona names) and runtime
+  (FS I/O patching) that public tests never touch real submodule content.
+
+A managed provider that cannot honour the privacy boundary for a given
+persona must not be eligible for that persona's binding. AgentCore Memory
+holding `personal` long-term memory is a fine pattern in the abstract but
+violates `personal`'s explicit data-sovereignty constraint; the same
+provider is appropriate for `work` if employer policy permits.
+
+## Non-goals
+
+Calling out things this architecture deliberately does **not** try to do:
+
+- **Lowest-common-denominator features across providers.** Roles should
+  declare what they need; bindings that can't supply it are rejected, not
+  silently downgraded.
+- **One-binding-per-repo.** The whole point is per-persona variation;
+  pressure to "just pick a stack" should be resisted unless the second
+  persona genuinely never materializes.
+- **Reimplementing managed services for parity.** The local providers exist
+  for sovereignty, learning, dev-loop speed, and air-gap scenarios — not
+  to match feature-for-feature with AgentCore Memory or Foundry. Where
+  the managed thing is dramatically better, the persona that needs it
+  should bind to it.
+- **Hiding provider identity from roles.** Roles can opt to require a
+  specific provider when behaviour is provider-specific (e.g. a role that
+  uses AgentCore Browser's session features). The capability matrix surfaces
+  this rather than hiding it.
+
+## Cross-references
+
+- [`interface-stability.md`](./interface-stability.md) — per-interface
+  stability classification and conformance status.
+- [`../gotchas.md`](../gotchas.md) — subtle traps, several of which
+  (G2, G6, G7) bear on the privacy boundary.
+- [`../observability.md`](../observability.md) — the only primitive
+  currently with end-to-end provider docs; templates the shape future
+  primitive docs should follow.
+- [`../../openspec/roadmap.md`](../../openspec/roadmap.md) — phase
+  sequence; P5/P11/P15/P16 are where most provider-binding work lands.

--- a/docs/architecture/primitives-and-providers.md
+++ b/docs/architecture/primitives-and-providers.md
@@ -43,23 +43,39 @@ persona-and-role concept itself (multi-tenant agent platforms achieve
 analogous boundaries; role-as-system-prompt-fragment is well-explored).
 The unprecedented combination is:
 
-- **Public code, private config via per-persona git submodules.** The
+- **Git itself as the multi-tenancy mechanism.** Instead of building
+  `tenant_id` into every table, API call, cache key, and policy check,
+  the repo offloads multi-tenancy entirely to git access control,
+  filesystem isolation, and per-persona process boundaries. The
+  primitives are **single-tenant by design** because two personas
+  never share a process; cross-persona work is cross-process (A2A).
+  This mirrors how Unix achieves per-user isolation via the kernel
+  rather than per-application code, how Kubernetes namespaces are
+  enforced by the control plane rather than each operator, and how
+  email isolates users via per-mailbox storage rather than a
+  user-id column on a shared `messages` table. The choice collapses
+  an enormous category of complexity that managed multi-tenant
+  platforms (AgentCore, Foundry, OpenAI Assistants) have to carry.
+- **Public code, private config via per-persona git submodules** is
+  the mechanism that implements the architectural choice above. The
   public repo can ship open-source while every persona's credentials,
   role overrides, DB schema, and skill set live in independent private
-  submodules under `personas/<name>/`. No managed agent platform offers
-  this split because they assume cloud-hosted tenant isolation; no
-  open-source framework offers it because they assume a single user.
-- **A two-layer privacy guard** (`tests/_privacy_guard_plugin.py` plus
-  `tests/conftest.py`) that enforces the public/private split at test
-  collection time (substring scan for private-persona identifiers) and
-  at runtime (FS I/O patching against private paths). This is the
-  artifact that turns the submodule split from convention into
-  contract.
+  submodules under `personas/<name>/`. No managed agent platform
+  offers this split because they assume cloud-hosted tenant isolation;
+  no open-source framework offers it because they assume a single
+  user.
+- **A two-layer privacy guard** (`tests/_privacy_guard_plugin.py`
+  plus `tests/conftest.py`) is the dev-time discipline that catches
+  attempts to bake private content into public artifacts. It enforces
+  the public/private split at test collection time (substring scan
+  for private-persona identifiers) and at runtime (FS I/O patching
+  against private paths). This is the artifact that turns the
+  submodule split from convention into contract.
 
 Persona-as-execution-boundary, role-as-overlay, and SPI-shaped provider
 selection are the *delivery vehicle* for that novelty. They are not the
 novelty themselves; they are well-trodden patterns adapted to carry
-the privacy boundary cleanly.
+the git-as-multi-tenancy choice cleanly.
 
 ## The primitive table
 
@@ -133,41 +149,60 @@ the provider bindings differ.
 
 Honest accounting of the matrix as of writing:
 
-**Interfaces realized in code:**
+**Interfaces realized in code (real implementations shipping):**
 
-- `HarnessAdapter` and its two tiers (`harnesses/base.py:12,24,48`) — narrow,
-  but a planned shrink is expected once `AgentRegistry` and
-  `CapabilityRegistry` land (sub-agent spawning and tool wiring move out of
-  the adapter).
-- `Extension` protocol (`extensions/base.py:15`) — currently leaky: the
-  `as_langchain_tools()` / `as_ms_agent_tools()` dual-surface bakes consumer
-  identity into the protocol. Slated for replacement by a
-  `register(registry, persona)` shape once `CapabilityRegistry` exists.
-- HTTP tool registry (`HttpToolRegistry` + OpenAPI discovery from persona
-  `tool_sources`) — partial implementation of the future
-  `CapabilityRegistry`. Four open follow-ups (#16–#19) address known gaps.
-- Observability — fully real via Langfuse with OTel-shaped spans, opt-in.
+- `HarnessAdapter` and its two tiers (`harnesses/base.py:12,24,48`) —
+  narrow, but a planned shrink is expected once `AgentRegistry` and
+  `CapabilityRegistry` land (sub-agent spawning and tool wiring move
+  out of the adapter). DeepAgents harness implemented; MS Agent
+  Framework harness implemented in P5 (archived).
+- `Extension` protocol (`extensions/base.py:15`) — currently leaky:
+  the `as_langchain_tools()` / `as_ms_agent_tools()` dual-surface
+  bakes consumer identity into the protocol. Slated for replacement
+  by a `register(registry, persona)` shape once `CapabilityRegistry`
+  exists. Real MS extensions ship (P5 archived); Google extensions
+  pending (P14).
+- `MemoryManager` (`core/memory.py:20`) — real, archived P2
+  memory-architecture. Postgres + Graphiti dual-backed; auto-selects
+  `PostgresGraphitiMemoryPolicy` when `database_url` configured.
+  Known leak: methods take `persona: str` parameter that should not
+  exist under git-as-multi-tenancy (see "Privacy boundary" above).
+- `HttpToolRegistry` + OpenAPI discovery from persona `tool_sources`
+  — real, archived P3 http-tools-layer. Substantial precursor to the
+  unified `CapabilityRegistry` proposed below. Four open follow-ups
+  (#16–#19) address known gaps.
+- Observability — real, archived P4 observability. Langfuse-backed
+  with OTel-shaped spans on `HarnessAdapter.invoke()`,
+  `DelegationSpawner.delegate()`, and memory operations.
+- Capability protocols (`GuardrailProvider`, `SandboxProvider`,
+  `MemoryPolicy`, `ToolPolicy`, `ContextProvider`) and
+  `CapabilityResolver` — real, archived P1.8 capability-protocols.
 
-**Interfaces planned but not yet defined:**
+**Interfaces planned but not yet defined as unified primitives:**
 
-- `CapabilityRegistry` (canonical form + projections) — design work pending.
-- `MemoryManager` — interface shape sketched (read/ingest/search/forget);
-  Postgres + Graphiti provider planned for the `memory-architecture` phase.
-- `IdentityProvider` — OpenBao integration exists at the script level
-  (`bao-vault` skill) but no agent-facing interface yet.
-- `SessionStore` — LangGraph checkpointers are used directly by the
-  DeepAgents adapter; lift to a primitive once a second harness needs the
-  same capability.
-- `Sandbox` — currently per-harness (Pi has `bash` built in; DeepAgents has
-  none yet). Lift when sandbox use becomes cross-harness.
-- `AgentRegistry` — implicit in `spawn_sub_agent` today; should be lifted
-  out of `HarnessAdapter`.
+- `CapabilityRegistry` — unifying primitive over `HttpToolRegistry`
+  plus extension tools and MCP servers, with multiple consumer
+  projections (LangChain, MSAF, Pi, MCP, CLI). Design pending in
+  the proposed `capability-registry` phase.
+- `IdentityProvider` — OpenBao integration exists at the script
+  level (`bao-vault` skill) but no agent-facing interface yet.
+- `SessionStore` — LangGraph `InMemorySaver` used directly by the
+  DeepAgents adapter (per archived fix-harness-conversation-memory).
+  Lift to a primitive once a second harness needs the same
+  capability.
+- `Sandbox` — currently per-harness. Lift when sandbox use becomes
+  cross-harness.
+- `AgentRegistry` — implicit in `spawn_sub_agent` today; should be
+  lifted out of `HarnessAdapter`.
+- `BindingManifest` — declarative deployment artifact unifying
+  `persona.yaml` + harness config + capability bindings + sink
+  configuration. Proposed as a foundational phase.
 
 **Interfaces deferred:**
 
-- `SkillResolver` — `.agents/skills/` layout is stable and consumed
-  directly today; formal interface waits until dynamic skill loading per
-  turn matters.
+- `SkillResolver` — `.agents/skills/` layout is stable and
+  consumed directly today; formal interface waits until dynamic
+  skill loading per turn matters.
 
 ## Cross-cutting concerns the matrix hides
 
@@ -198,8 +233,10 @@ not rediscovered per integration:
   checkpoint support + memory replay safety). The capability matrix
   is per-interface; the binding validator must express constraints
   *across* interfaces or it cannot reject incompatible provider mixes
-  at startup. This is the largest known gap in the current design and
-  is the most likely place a future role exposes a real bug.
+  at startup. Compatibility groups are formalized as artifacts within
+  the proposed `binding-manifest` phase (the binding manifest is the
+  declarative artifact the validator runs against); until that lands,
+  they are documented here as a convention rather than enforced.
 
 These cross-cuts are not new primitives. They are conventions that
 several primitives must agree on. They live in this document and the
@@ -273,27 +310,61 @@ This pattern only delivers on its promise if three disciplines are followed:
 
 ## Privacy boundary
 
-The persona-as-sovereign-execution-boundary claim is not aspirational — it
-is enforced at three layers and must be preserved by any new provider
-binding:
+The persona-as-sovereign-execution-boundary is enforced by **deployment
+topology**, not by defensive code in the primitive interfaces. Each
+persona is a separate deployment with its own DB, its own credentials,
+its own process. Two personas never share an address space, a connection
+string, or a credential vault. Cross-persona reads are not "prevented by
+the interface" — they are *physically impossible* because the topology
+forbids shared infrastructure. The interfaces are single-persona by
+design because, by topology, they will only ever be constructed inside
+a process bound to exactly one persona.
 
-- **Code layer:** persona-specific config lives in private submodules under
-  `personas/<name>/`; the public repo never imports from them, only from
-  fixture copies under `tests/fixtures/personas/`.
-- **Data layer:** each persona has its own database; the `MemoryManager`
-  interface must make cross-persona reads physically impossible (instances
-  bind to a `PersonaConfig` at construction; there is no `manager.get(
-  persona=other, ...)`).
+This shifts what each layer of the privacy guard does:
+
+- **Topology layer (load-bearing):** each persona is its own
+  deployment — per-persona DB, per-persona vault, per-persona
+  process. Run two personas, get two processes (same machine,
+  separate hosts, separate clouds — all equivalent from the
+  architecture's perspective). The primitives observe one persona
+  at construction and never have a reason to know about others.
+- **Code layer:** persona-specific config lives in private git
+  submodules under `personas/<name>/`; the public repo never
+  imports from them, only from fixture copies under
+  `tests/fixtures/personas/`. This is the dev-time discipline that
+  prevents private content from being baked into public artifacts.
 - **Test layer:** the two-layer privacy guard
-  (`tests/conftest.py` + `tests/_privacy_guard_plugin.py`) enforces at
-  collection time (substring scan for private-persona names) and runtime
-  (FS I/O patching) that public tests never touch real submodule content.
+  (`tests/conftest.py` + `tests/_privacy_guard_plugin.py`) catches
+  dev-time leakage at test collection (substring scan for
+  private-persona identifiers) and at runtime (FS I/O patching).
+  Its job is **narrow** — catch developer mistakes that would bake
+  private content into public artifacts. It is not preventing
+  runtime cross-tenant access, because the topology has already made
+  that impossible.
 
-A managed provider that cannot honour the privacy boundary for a given
-persona must not be eligible for that persona's binding. AgentCore Memory
-holding `personal` long-term memory is a fine pattern in the abstract but
-violates `personal`'s explicit data-sovereignty constraint; the same
-provider is appropriate for `work` if employer policy permits.
+A managed provider that cannot honour the topology constraint for a
+given persona must not be eligible for that persona's binding.
+AgentCore Memory holding `personal` long-term memory violates
+`personal`'s explicit data-sovereignty constraint; the same provider is
+appropriate for `work` if employer policy permits.
+
+### A known interface leak
+
+`MemoryManager` at `src/assistant/core/memory.py:20` currently takes
+`persona: str` as a parameter on methods like `get_context()`,
+`store_fact()`, and similar (e.g. `memory.py:30, 65`). Under
+git-as-multi-tenancy this parameter is **leakage from a defunct
+multi-tenant assumption**: each `MemoryManager` instance is constructed
+inside a process that is already bound to exactly one persona (the
+`session_factory` is per-persona), so the method parameter cannot
+validly differ from the instance's persona. The caller shouldn't have
+to supply information the instance already knows.
+
+The cleanup is mechanical — drop the parameter, the instance is the
+persona's manager — and folds naturally into the `binding-manifest`
+phase. Tracked as a load-bearing leak in
+[`interface-stability.md`](./interface-stability.md) →
+`MemoryManager`.
 
 ## Non-goals
 

--- a/openspec/changes/binding-manifest/proposal.md
+++ b/openspec/changes/binding-manifest/proposal.md
@@ -1,0 +1,296 @@
+# Proposal: binding-manifest
+
+## Why
+
+Today a persona is defined by an ad-hoc mix of files: `persona.yaml`
+under `personas/<name>/`, harness configuration scattered across
+`harnesses.*` keys in that file, role overrides under
+`personas/<name>/roles/`, environment-supplied database URLs, OpenBao
+secret paths read by various scripts, and observability sink choices
+inferred from environment variables. There is no single artifact that
+declares "this is the deployment binding for persona X" — which model,
+which harness, which memory backend, which identity provider, which
+observability sink, which tool catalog, which sandbox provider.
+
+This matters for three reasons that the architecture work in
+`docs/architecture/primitives-and-providers.md` and
+`docs/architecture/interface-stability.md` exposed:
+
+1. **The SPI claim is verifiable only against a declared binding.** The
+   stability ledger says providers slot behind interfaces per persona,
+   but "per persona" has no formal expression today. A binding-validator
+   that checks "this persona's chosen providers actually satisfy the
+   capabilities the bound roles require" cannot exist without a manifest
+   to validate against.
+2. **Compatibility groups (cross-primitive role requirements) need an
+   artifact to enforce against.** Some role requirements span multiple
+   primitives (e.g. `interrupt_resume` needs harness support + session
+   checkpoint support + memory replay safety). The capability matrix is
+   per-interface; compatibility groups are cross-interface. Without a
+   manifest, the validator has nowhere to run.
+3. **`MemoryManager` has a load-bearing leak** (`src/assistant/core/memory.py`
+   methods accepting `persona: str` that under git-as-multi-tenancy is
+   invariant per process). The cleanup — drop the parameter, instance
+   is already persona-bound — needs a declarative artifact that names
+   the persona at construction so callers stop passing it around.
+
+Defining the binding manifest now — before lifting `CapabilityRegistry`
+(proposed next), before adding Pi as a third harness, before
+provisioning the work-persona deployment — means those phases build
+against a single declarative artifact rather than continuing the
+implicit-config-everywhere pattern.
+
+## What Changes
+
+### 1. Binding manifest schema
+
+Introduce a YAML schema at `personas/<name>/binding.yaml` (additive to
+`persona.yaml`; `binding.yaml` is the deployment-shaped artifact,
+`persona.yaml` continues to hold persona-identity fields) that
+declares:
+
+```yaml
+binding:
+  manifest_version: 1
+  persona: personal
+  providers:
+    model:
+      provider: anthropic
+      model_id: claude-sonnet-4-5
+      capabilities: [tool_calling, vision, thinking]
+    harnesses:
+      - kind: deep_agents
+        default: true
+        capabilities: [multi_agent_native, plan_mode]
+      - kind: ms_agent_framework
+        capabilities: [structured_output]
+    memory:
+      provider: postgres_graphiti
+      connection: ${ASSISTANT_DATABASE_URL}
+      capabilities: [semantic_search, forget, async_ingestion]
+    identity:
+      provider: openbao
+      mount: ${ASSISTANT_VAULT_MOUNT}
+      capabilities: [oauth_refresh, audit_trail]
+    capability_registry:
+      provider: http_tools
+      sources: ${ASSISTANT_TOOL_SOURCES}
+      capabilities: [openapi_discovery]
+    observability:
+      provider: langfuse
+      endpoint: ${LANGFUSE_HOST}
+      capabilities: [span_export]
+    sandbox:
+      provider: passthrough
+      capabilities: []
+  compatibility_groups:
+    - name: interrupt_resume
+      requires:
+        harness: interrupt_resume
+        session: checkpoint_mid_turn
+        memory: replay_safe
+```
+
+The schema lives in `src/assistant/core/binding/schema.py` (Pydantic
+models), with JSON Schema generated for editor support.
+
+### 2. Binding validator
+
+Introduce `src/assistant/core/binding/validator.py` that consumes a
+`BindingManifest` and asserts:
+
+- Every named provider exists in the registry of known providers
+- Every advertised capability is supported by the provider implementation
+- Every compatibility group's requirements are satisfied by the bound
+  providers' advertised capabilities
+- Every role under `personas/<name>/roles/` that declares
+  `requires_capabilities:` has its requirements satisfied by at least
+  one binding (per role, per harness)
+
+Failures are loud (raised at process startup, before the REPL starts),
+not deferred to the first turn that exercises the missing capability.
+
+### 3. CLI `binding` subcommand
+
+Add `assistant binding {check,show,explain}`:
+
+- `check` — runs the validator against the current persona; exits
+  non-zero on failure
+- `show` — pretty-prints the resolved binding (providers, capabilities,
+  satisfied compatibility groups)
+- `explain <capability>` — for diagnostic use; shows which provider is
+  expected to supply a named capability for the current persona
+
+### 4. `MemoryManager` interface cleanup (BREAKING)
+
+Drop the `persona: str` parameter from `MemoryManager` methods
+(`get_context`, `store_fact`, `store_interaction`, `update_preference`,
+`list_facts`, etc.). The instance is constructed from the binding
+manifest's memory provider configuration, which is already
+persona-scoped via the per-persona `session_factory`. The method
+parameter was invariant-per-process leakage from a multi-tenant
+assumption that doesn't hold under git-as-multi-tenancy.
+
+Update `src/assistant/core/memory.py` and all call sites; update
+`MemoryPolicy` protocol accordingly. Migrate tests.
+
+### 5. `PersonaConfig` → binding integration
+
+`src/assistant/core/persona.py` `PersonaRegistry.load(name)` is extended
+to also load `binding.yaml`, validate it, and surface the resolved
+`BindingManifest` as `persona.binding`. The CLI startup path
+(`src/assistant/cli.py`) consumes `persona.binding` to instantiate
+harness, memory, identity, observability, etc.
+
+### 6. Compatibility group declarations on roles
+
+Roles under `roles/<name>/role.yaml` and persona-specific overrides may
+declare:
+
+```yaml
+requires_capabilities:
+  - compatibility_group: interrupt_resume
+  - capability: harness.streaming
+  - capability: memory.semantic_search
+```
+
+The binding validator checks these declarations against the manifest's
+providers at startup.
+
+## Approaches Considered
+
+### Approach A: Extend `persona.yaml` with a `binding:` top-level key — Effort: S
+
+**Description**: Keep one config file per persona; add a `binding:`
+section to `persona.yaml`.
+
+- **Pros**: Single file per persona; no new artifact; minimal
+  migration; backward-compatible.
+- **Cons**: `persona.yaml` already mixes identity, defaults, schedules,
+  and harness config; adding binding overloads it further. The
+  deployment artifact is structurally different from the
+  persona-identity artifact (deployment is per-deployment, identity
+  is per-persona-across-deployments). Conflating them blocks future
+  multi-deployment-per-persona scenarios (dev / staging / prod
+  bindings of the same persona).
+
+### Approach B (Recommended): Separate `binding.yaml` artifact alongside `persona.yaml` — Effort: M
+
+**Description**: Add `binding.yaml` as the deployment-shaped artifact;
+`persona.yaml` continues to hold persona-identity fields. Loader
+composes both.
+
+- **Pros**: Deployment artifact is structurally distinct from identity
+  artifact; supports multiple bindings of the same persona (dev /
+  staging / prod) via `binding.dev.yaml`, `binding.prod.yaml`;
+  validator runs against the binding alone; cleaner separation of
+  concerns.
+- **Cons**: Two files instead of one; migration writes new files for
+  existing personas. Mitigated by the loader synthesizing a default
+  `binding.yaml` from the legacy `persona.yaml` `harnesses.*` keys when
+  no explicit `binding.yaml` exists, deprecation-warning users to add
+  an explicit file.
+
+### Approach C: External binding registry service — Effort: L
+
+**Description**: Manifests live in a separate service (e.g.
+configuration store, OpenBao path, an HTTP endpoint); the persona's
+local config declares only its name and the registry URL.
+
+- **Pros**: Centralized binding management; bindings updatable without
+  redeploying; useful for fleet-of-personas scenarios.
+- **Cons**: Adds infrastructure dependency for what is fundamentally
+  a per-deployment artifact; conflicts with git-as-multi-tenancy
+  (each persona is its own git repo with its own config); over-engineered
+  for the current ≤2 personas case.
+
+### Selected Approach: **B — Separate `binding.yaml` artifact**
+
+Chosen because it preserves the deployment-vs-identity distinction
+that git-as-multi-tenancy makes possible, supports multi-binding
+scenarios cleanly, and keeps the validator's input scope minimal.
+Unselected:
+
+- **A** rejected: overloads `persona.yaml` and blocks
+  multi-binding-per-persona. The marginal simplicity of "one file"
+  is not worth the conflation.
+- **C** rejected: contradicts git-as-multi-tenancy; over-engineered
+  for current scale.
+
+## Capabilities
+
+### New Capabilities
+
+- `binding-manifest`: Declarative YAML artifact at
+  `personas/<name>/binding.yaml` enumerating providers, advertised
+  capabilities, and compatibility groups for a persona deployment.
+  Validated at process startup; surfaced as `persona.binding`.
+- `binding-validator`: Runtime validator that asserts every named
+  provider exists, every advertised capability is supported, every
+  compatibility group is satisfied, and every role's required
+  capabilities are met by the bound providers.
+- `binding-cli`: `assistant binding {check,show,explain}` subcommands
+  for human and CI use.
+
+### Modified Capabilities
+
+- `memory-policy`: `MemoryManager` methods drop the `persona: str`
+  parameter. Instance is persona-bound at construction via the
+  manifest's memory provider configuration. **BREAKING**.
+- `persona-registry`: `PersonaRegistry.load(name)` extended to load
+  `binding.yaml`, validate it, and attach a resolved
+  `BindingManifest` to the `PersonaConfig` as `persona.binding`.
+  Backward-compatible synthesizer: when `binding.yaml` is absent, a
+  default manifest is generated from the legacy `persona.yaml`
+  `harnesses.*` keys plus environment-supplied connection strings,
+  with a deprecation warning.
+- `role-registry`: Role definitions may declare
+  `requires_capabilities:` (compatibility group or capability). The
+  validator enforces these against the binding.
+
+## Impact
+
+- **Affected code**: `src/assistant/core/binding/` (new), `src/assistant/core/persona.py` (loader),
+  `src/assistant/core/memory.py` (drop persona param),
+  `src/assistant/core/role.py` (parse `requires_capabilities`),
+  `src/assistant/cli.py` (binding subcommand + startup validation),
+  most call sites of `MemoryManager.*` methods (drop persona arg).
+- **Affected specs**: `memory-policy` (modified — persona param drop),
+  `persona-registry` (modified — binding attached), `role-registry`
+  (modified — `requires_capabilities` field), new: `binding-manifest`,
+  `binding-validator`, `binding-cli`.
+- **Dependencies**: P1.8 capability-protocols (CapabilitySet exists),
+  P2 memory-architecture (MemoryManager exists and needs cleanup),
+  P3 http-tools-layer (HttpToolRegistry exists as one provider),
+  P4 observability (Langfuse provider exists), P5 ms-graph-extension
+  (MS Agent Framework harness exists). All archived; no blockers.
+- **Breaking changes**: `MemoryManager` method signatures; all
+  call sites updated in this change. Personas without
+  `binding.yaml` continue to work via the legacy-synthesizer with
+  a deprecation warning; behaviour unchanged until they explicitly
+  migrate.
+
+## Out of Scope (deferred to later phases)
+
+- **`CapabilityRegistry` lifting** — unifying `HttpToolRegistry`,
+  extension tools, and MCP servers behind a single registry with
+  multiple projections is the proposed `capability-registry` phase,
+  which depends on this one (the binding declares which
+  CapabilityRegistry provider is in use).
+- **Pi harness** — `pi-harness` phase depends on `capability-registry`
+  for MCP projection of tools; not in scope here.
+- **Persona deployment kit** — the scripts and templates that
+  scaffold a new persona deployment end-to-end (DB provisioning,
+  vault provisioning, etc.) are the proposed `persona-deployment-kit`
+  phase. This change defines the manifest the kit will populate;
+  the kit itself is separate.
+- **Conformance test harness** — `tests/conformance/` infrastructure
+  for SPI conformance is the proposed `conformance-test-harness`
+  phase. This change writes scenario-level tests for the binding
+  validator only.
+- **Multi-binding-per-persona** (dev / staging / prod bindings) —
+  the schema is designed to support `binding.dev.yaml` /
+  `binding.prod.yaml` selection, but the loader only handles the
+  default `binding.yaml` in this change.
+- **Hot-reload of bindings** — bindings are read at startup; runtime
+  rebinding is not supported.

--- a/openspec/changes/binding-manifest/specs/binding-manifest/spec.md
+++ b/openspec/changes/binding-manifest/specs/binding-manifest/spec.md
@@ -1,0 +1,226 @@
+# binding-manifest — spec delta
+
+## ADDED Requirements
+
+### Requirement: BindingManifest Schema
+
+The system SHALL define a Pydantic `BindingManifest` model that loads
+and validates a `binding.yaml` file with a `binding:` top-level key
+and `manifest_version`, `persona`, `providers`, and
+`compatibility_groups` fields.
+
+#### Scenario: Valid manifest parses
+
+- **WHEN** `BindingManifest.load(path)` is called with a YAML file
+  containing valid `manifest_version: 1`, `persona`, `providers`, and
+  `compatibility_groups` fields
+- **THEN** the call MUST return a `BindingManifest` instance
+- **AND** every named provider MUST be accessible as a typed attribute
+- **AND** every compatibility group MUST be accessible as a list
+  attribute
+
+#### Scenario: Unknown manifest version rejected
+
+- **WHEN** `BindingManifest.load(path)` is called with
+  `manifest_version: 99`
+- **THEN** the call MUST raise `BindingSchemaError` naming the
+  unsupported version
+
+#### Scenario: Missing required provider rejected
+
+- **WHEN** `BindingManifest.load(path)` is called with a YAML file
+  missing the required `providers.model` key
+- **THEN** the call MUST raise `BindingSchemaError` naming the missing
+  provider slot
+
+### Requirement: Provider Binding Slots
+
+The system SHALL define a fixed enumeration of provider binding slots
+(`model`, `harnesses`, `memory`, `identity`, `capability_registry`,
+`observability`, `sandbox`) such that each binding manifest declares
+exactly one provider for each slot, except `harnesses` which accepts
+a list with at least one entry marked `default: true`.
+
+#### Scenario: Multiple harnesses with one default
+
+- **WHEN** a manifest declares two harnesses in `providers.harnesses`,
+  one with `default: true`
+- **THEN** the parsed manifest MUST expose both harnesses
+- **AND** `manifest.providers.harnesses.default` MUST return the
+  default-marked harness
+
+#### Scenario: No default harness rejected
+
+- **WHEN** a manifest declares two harnesses with neither marked
+  `default: true`
+- **THEN** `BindingManifest.load(path)` MUST raise `BindingSchemaError`
+  naming the missing-default failure
+
+### Requirement: Compatibility Group Declarations
+
+The system SHALL parse `compatibility_groups` entries each containing
+`name` and `requires` fields, where `requires` is a mapping from
+provider slot name to required capability identifier.
+
+#### Scenario: Compatibility group parses
+
+- **WHEN** a manifest declares a compatibility group named
+  `interrupt_resume` with `requires` mapping
+  `{harness: interrupt_resume, session: checkpoint_mid_turn,
+  memory: replay_safe}`
+- **THEN** `manifest.compatibility_groups[0].name` MUST equal
+  `"interrupt_resume"`
+- **AND** `manifest.compatibility_groups[0].requires["harness"]` MUST
+  equal `"interrupt_resume"`
+
+### Requirement: Environment Variable Interpolation
+
+The system SHALL interpolate environment variables of the form
+`${NAME}` in string values within the manifest, evaluating them
+against the process environment at load time.
+
+#### Scenario: Environment variable interpolated
+
+- **GIVEN** the environment variable `ASSISTANT_DATABASE_URL` is set
+  to `postgresql://localhost/personal`
+- **WHEN** a manifest with `providers.memory.connection:
+  ${ASSISTANT_DATABASE_URL}` is loaded
+- **THEN** `manifest.providers.memory.connection` MUST equal
+  `"postgresql://localhost/personal"`
+
+#### Scenario: Missing environment variable rejected
+
+- **GIVEN** the environment variable `ASSISTANT_VAULT_MOUNT` is unset
+- **WHEN** a manifest with `providers.identity.mount:
+  ${ASSISTANT_VAULT_MOUNT}` is loaded
+- **THEN** `BindingManifest.load(path)` MUST raise
+  `BindingSchemaError` naming the unset variable
+
+### Requirement: Legacy Synthesis
+
+The system SHALL synthesize a default `BindingManifest` from the
+legacy `persona.yaml` `harnesses.*` keys plus environment-supplied
+connection strings when no `binding.yaml` file exists, with a
+deprecation warning naming the persona.
+
+#### Scenario: Legacy persona produces a default manifest
+
+- **GIVEN** a persona directory containing `persona.yaml` with
+  `harnesses.deep_agents.enabled: true` but no `binding.yaml`
+- **WHEN** `BindingManifest.synthesize_from_legacy(persona_config)`
+  is called
+- **THEN** the call MUST return a `BindingManifest` with
+  `providers.harnesses` containing a `deep_agents` entry marked
+  `default: true`
+- **AND** a `DeprecationWarning` MUST be emitted naming the persona
+  and recommending an explicit `binding.yaml`
+
+### Requirement: Validator Loud-Failure
+
+The system SHALL provide a `BindingValidator.validate(manifest,
+role_registry, provider_registry)` method that raises
+`BindingValidationError` containing a list of all failures (provider
+not found, capability not supported, compatibility group unsatisfied,
+role required capability unsatisfied) rather than stopping at the
+first failure.
+
+#### Scenario: Multiple failures collected
+
+- **WHEN** a manifest declares an unknown provider AND a role
+  requiring an unsatisfiable capability are both validated
+- **THEN** `BindingValidator.validate` MUST raise
+  `BindingValidationError`
+- **AND** the raised error MUST contain at least two failure entries
+- **AND** each failure entry MUST name the specific failing
+  component (provider name, capability identifier, role name)
+
+#### Scenario: Valid manifest passes
+
+- **WHEN** a manifest declares only known providers, only supported
+  capabilities, and all compatibility groups are satisfiable
+- **AND** all roles' `requires_capabilities` are satisfied
+- **THEN** `BindingValidator.validate` MUST return without raising
+
+### Requirement: PersonaRegistry Integration
+
+The system SHALL extend `PersonaRegistry.load(name)` to load
+`binding.yaml` (or synthesize from legacy), validate it, and attach
+the resolved `BindingManifest` to the returned `PersonaConfig` as a
+`binding` attribute.
+
+#### Scenario: PersonaConfig exposes resolved binding
+
+- **WHEN** `PersonaRegistry.load("personal")` is called with a
+  persona directory containing a valid `binding.yaml`
+- **THEN** the returned `PersonaConfig` MUST have a `binding`
+  attribute
+- **AND** `persona.binding` MUST be a `BindingManifest` instance
+- **AND** `persona.binding.persona` MUST equal `"personal"`
+
+#### Scenario: Invalid binding fails at load time
+
+- **WHEN** `PersonaRegistry.load("personal")` is called with a
+  persona directory containing an invalid `binding.yaml`
+- **THEN** the call MUST raise `BindingValidationError`
+- **AND** the REPL MUST NOT start
+
+### Requirement: CLI Binding Subcommand
+
+The system SHALL provide an `assistant binding` subcommand with three
+verbs: `check` (run the validator, exit 0 on success / non-zero on
+failure), `show` (pretty-print the resolved manifest), and `explain
+<capability>` (name the providing implementation for a capability
+identifier).
+
+#### Scenario: Check succeeds on valid persona
+
+- **WHEN** `assistant binding check -p personal` is invoked against
+  a persona with a valid binding
+- **THEN** the command MUST exit with code 0
+- **AND** stdout MUST contain a success message naming the validated
+  persona
+
+#### Scenario: Check fails with formatted error
+
+- **WHEN** `assistant binding check -p personal` is invoked against
+  a persona with an invalid binding
+- **THEN** the command MUST exit with non-zero code
+- **AND** stderr MUST contain a list of validation failures, one per
+  line
+
+## MODIFIED Requirements
+
+### Requirement: MemoryManager Methods Persona-Agnostic
+
+The `MemoryManager` interface SHALL NOT accept a `persona` parameter
+on any method. The instance is persona-bound at construction via the
+`session_factory` (which is itself persona-scoped per the binding
+manifest).
+
+This MODIFIES the prior memory-policy contract that accepted
+`persona: str` on `get_context`, `store_fact`, `store_interaction`,
+`update_preference`, `list_facts`, and similar methods.
+
+#### Scenario: get_context signature
+
+- **WHEN** the caller invokes `manager.get_context(role="researcher",
+  limit=50)`
+- **THEN** the call MUST return the active and semantic context
+  sections for the bound persona's `researcher` role
+- **AND** no `persona` parameter MUST appear in the signature
+
+#### Scenario: store_fact signature
+
+- **WHEN** the caller invokes `manager.store_fact(key="preferred_lang",
+  value="en")`
+- **THEN** the call MUST persist the fact for the bound persona
+- **AND** no `persona` parameter MUST appear in the signature
+
+#### Scenario: Persona name available for observability
+
+- **WHEN** a memory operation traces a span
+- **THEN** the span attribute `assistant.persona` MUST equal the bound
+  persona's name
+- **AND** the persona name MUST be read from the MemoryManager
+  instance's internal `_persona_name`, NOT from a caller-supplied
+  parameter

--- a/openspec/changes/binding-manifest/tasks.md
+++ b/openspec/changes/binding-manifest/tasks.md
@@ -1,0 +1,158 @@
+# Tasks — binding-manifest
+
+Tasks are ordered TDD-style within each phase: test tasks first,
+implementation tasks depend on their corresponding tests. Phases are
+ordered so each builds on a compileable/importable tree from the
+prior phase.
+
+## Phase 1 — Schema and types
+
+- [ ] 1.1 Write `tests/core/binding/test_schema.py` encoding the
+  scenarios from `specs/binding-manifest/spec.md`:
+  - `BindingManifest` parses a valid `binding.yaml`
+  - `BindingManifest` rejects unknown providers
+  - `BindingManifest` rejects unknown capabilities for a known
+    provider
+  - `BindingManifest` parses compatibility groups
+  - `BindingManifest` round-trips through YAML
+  **Spec scenarios**: all from `binding-manifest` spec.
+  **Dependencies**: none
+
+- [ ] 1.2 Implement `src/assistant/core/binding/__init__.py` and
+  `src/assistant/core/binding/schema.py`:
+  - Pydantic models: `BindingManifest`, `ProvidersBinding`,
+    `ModelBinding`, `HarnessBinding`, `MemoryBinding`,
+    `IdentityBinding`, `CapabilityRegistryBinding`,
+    `ObservabilityBinding`, `SandboxBinding`, `CompatibilityGroup`
+  - `BindingManifest.load(path: Path) → BindingManifest`
+  - `BindingManifest.synthesize_from_legacy(persona: PersonaConfig)
+    → BindingManifest` (for backward compatibility)
+  - Generate JSON Schema for editor support; commit under
+    `personas/_template/schemas/binding.schema.json`
+  **Design decisions**: see `design.md` (to be authored via
+  /plan-feature).
+  **Dependencies**: 1.1
+
+## Phase 2 — Validator
+
+- [ ] 2.1 Write `tests/core/binding/test_validator.py` encoding the
+  scenarios from `specs/binding-validator/spec.md`:
+  - Unknown provider rejected at startup
+  - Provider missing an advertised capability rejected
+  - Compatibility group unsatisfied rejected
+  - Role with `requires_capabilities` unsatisfied rejected
+  - Valid manifest passes validation
+  **Spec scenarios**: all from `binding-validator` spec.
+  **Dependencies**: 1.2
+
+- [ ] 2.2 Implement `src/assistant/core/binding/validator.py`:
+  - `BindingValidator.validate(manifest, role_registry, provider_registry)`
+  - `ProviderRegistry` — central registry of known providers and
+    their advertised capabilities; populated from existing modules
+    (DeepAgentsHarness, MSAgentFrameworkHarness, MemoryManager,
+    HttpToolRegistry, LangfuseProvider, etc.)
+  - Failure mode: raise `BindingValidationError` with full list of
+    failures (don't stop at first)
+  **Dependencies**: 2.1
+
+## Phase 3 — MemoryManager cleanup (BREAKING)
+
+- [ ] 3.1 Write `tests/core/test_memory_persona_param_removed.py`
+  encoding that `MemoryManager` methods no longer accept `persona`:
+  - `get_context(role, limit=…)` signature
+  - `store_fact(key, value)` signature
+  - `store_interaction(…)` signature
+  - `update_preference(…)` signature
+  - `list_facts()` signature
+  **Spec scenarios**: from modified `memory-policy` spec.
+  **Dependencies**: none (independent of binding phases)
+
+- [ ] 3.2 Refactor `src/assistant/core/memory.py`:
+  - Drop `persona: str` from `get_context`, `store_fact`,
+    `store_interaction`, `update_preference`, `list_facts`, and any
+    other persona-parameterized method
+  - Add `self._persona_name: str` set at construction (for
+    logging/observability) from the session_factory's persona binding
+  - Update `@trace_memory_op` to read persona from
+    `self._persona_name`
+  **Dependencies**: 3.1
+
+- [ ] 3.3 Update all call sites:
+  - `src/assistant/cli.py` REPL code
+  - `src/assistant/harnesses/sdk/deep_agents.py`
+  - `src/assistant/harnesses/sdk/ms_agent_fw.py`
+  - `src/assistant/delegation/*`
+  - Any extension code that touches MemoryManager
+  - Existing tests in `tests/core/test_memory.py` and elsewhere
+  **Dependencies**: 3.2
+
+- [ ] 3.4 Update `MemoryPolicy` protocol in
+  `src/assistant/core/capabilities/` to match new method signatures.
+  **Dependencies**: 3.2
+
+## Phase 4 — PersonaRegistry integration
+
+- [ ] 4.1 Write `tests/core/test_persona_binding_load.py` encoding:
+  - `PersonaRegistry.load(name)` returns a `PersonaConfig` with
+    `binding` attribute when `binding.yaml` exists
+  - `PersonaRegistry.load(name)` synthesizes a binding (with
+    deprecation warning) when `binding.yaml` is absent
+  - Validation fails loudly at load time for invalid bindings
+  **Dependencies**: 1.2, 2.2
+
+- [ ] 4.2 Extend `src/assistant/core/persona.py`:
+  - Load `binding.yaml` if present
+  - Synthesize from legacy `persona.yaml` `harnesses.*` keys if not
+  - Run validator before returning the PersonaConfig
+  - Attach resolved `BindingManifest` as `persona.binding`
+  **Dependencies**: 4.1
+
+## Phase 5 — Role requires_capabilities
+
+- [ ] 5.1 Write `tests/core/test_role_requires_capabilities.py`:
+  - Role with `requires_capabilities: [{capability: foo.bar}]`
+    parses
+  - Role with unknown capability key rejected
+  - Validator integration: persona with role X but no provider for
+    X's required capabilities is rejected
+  **Dependencies**: 2.2
+
+- [ ] 5.2 Extend `src/assistant/core/role.py` to parse
+  `requires_capabilities`; thread through to validator at
+  `PersonaRegistry.load` time.
+  **Dependencies**: 5.1
+
+## Phase 6 — CLI subcommand
+
+- [ ] 6.1 Write `tests/cli/test_binding_subcommand.py`:
+  - `assistant binding check -p personal` runs validator and exits 0
+    on success
+  - `assistant binding check -p personal` exits non-zero on failure
+    with formatted error
+  - `assistant binding show -p personal` prints resolved manifest
+  - `assistant binding explain memory.semantic_search -p personal`
+    names the providing implementation
+  **Dependencies**: 4.2, 5.2
+
+- [ ] 6.2 Implement `assistant binding` subcommand in
+  `src/assistant/cli.py`.
+  **Dependencies**: 6.1
+
+## Phase 7 — Template + docs
+
+- [ ] 7.1 Add `personas/_template/binding.yaml` showing the schema
+  with annotated comments.
+
+- [ ] 7.2 Add `personas/_template/schemas/binding.schema.json`
+  generated from Pydantic for editor support.
+
+- [ ] 7.3 Document the binding manifest in
+  `docs/architecture/binding-manifest.md` (operational reference,
+  complementary to `primitives-and-providers.md`'s architectural
+  framing).
+
+- [ ] 7.4 Update `docs/architecture/primitives-and-providers.md` to
+  cross-reference the now-real binding manifest; update
+  `docs/architecture/interface-stability.md` to mark
+  `BindingManifest` interface as Provisional (real, one provider,
+  has conformance suite).

--- a/openspec/roadmap.md
+++ b/openspec/roadmap.md
@@ -38,19 +38,25 @@
 | P3 | `http-tools-layer` | phase | **archived** (2026-04-24) | §8.2 | perplexity §8.2 + old P2 | `src/assistant/http_tools/` — `/openapi.json`-based discovery with `$ref` resolution (D10), `_build_tool()` Pydantic-model + async-callable generator, auth header handling (D11 structured + legacy compat), registry, `--list-tools` CLI flag, integration tests against mock server under D9 security posture (streaming 10 MiB cap, no redirects, credential redaction) |
 | P4 | `observability` | phase | **archived** (2026-05-03) | §1.1, §8.3 | perplexity §8.3 (new) | `core/observability.py` — `@traced` decorator, spans on `HarnessAdapter.invoke()` and `DelegationSpawner.delegate()`, token + latency + cost tracking per persona/role. Langfuse backend default; OpenLLMetry adapter optional |
 | P5 | `ms-graph-extension` | phase | **archived** (2026-05-09) | §8.4 | perplexity §8.4 + old P5 | Real `ms_graph`, `teams`, `sharepoint`, `outlook` extensions (replaces P1 stubs). MSAL auth, httpx client, OAuth refresh. Full MS Agent Framework harness implementation replacing P1's `NotImplementedError` stub |
-| P6 | `a2a-server` | phase | pending | §6, §8.5 | perplexity §8.5 (new; was Phase-16 "out of scope") | `src/assistant/a2a/` — server.py, task_handler.py, agent_card.py. Exposes `/a2a/v1/message:stream` endpoint. Serves `.well-known/agent.json`. Lets Copilot Studio Chief of Staff delegate to this assistant |
+| P5.5 | `binding-manifest` | phase | pending | — | new (SPI framing follow-up, docs/architecture/) | Declarative `binding.yaml` per persona naming providers per primitive slot (model, harnesses, memory, identity, capability_registry, observability, sandbox); `BindingValidator` at startup with loud failures and compatibility-group enforcement; **BREAKING** `MemoryManager` cleanup (drop `persona: str` param — invariant per process under git-as-multi-tenancy); CLI `assistant binding {check,show,explain}`. Foundational for P5.6 / P5.7 / P14.5 / P15 / P18. Proposal lives at `openspec/changes/binding-manifest/`. |
+| P5.6 | `capability-registry` | phase | pending | — | new (SPI framing follow-up) | Unifying primitive over `HttpToolRegistry` + extension tools + MCP servers with multiple consumer projections (LangChain, MSAF, Pi, MCP, CLI). OpenAPI canonical form + AA extensions (streaming, scoping, per-projection auth). Replaces `Extension` dual-surface methods (`as_langchain_tools()` / `as_ms_agent_tools()`) with `register(registry)` per documented leak in `docs/architecture/interface-stability.md`. Depends on P5.5 binding-manifest (registry provider declared in binding). |
+| P5.7 | `conformance-test-harness` | phase | pending | — | new (SPI framing follow-up) | `tests/conformance/` infrastructure with shared fixtures; defines local-vs-managed conformance tier split per `docs/architecture/interface-stability.md`; gates stability promotion from Experimental → Provisional. Prerequisite for any new provider phase (P5.8 pi-harness, P14 google-extensions). |
+| P5.8 | `pi-harness` | phase | pending | — | new (SPI framing follow-up) | Adds Pi (https://pi.dev/, github.com/earendil-works/pi) as a third harness adapter via `pi --mode rpc` subprocess + LF-delimited JSONL bridge. Validates `capability-registry` end-to-end with a non-Python harness consumer; proves the SPI claim by adding a non-Python harness without per-extension changes. Depends on P5.6 capability-registry (for MCP projection of tools); conformance via P5.7. |
+| P5.9 | `interface-stability-ci-gate` | non-phase (tooling) | pending | — | new (ledger discipline) | CI check that fails when files under `src/assistant/{harnesses,extensions,core/memory,telemetry}/` are modified without a corresponding `docs/architecture/interface-stability.md` touch. Implements the "ledger drift mitigation" discipline from the architecture docs. Can land any time after P5.7. |
+| P6 | `a2a-server` | phase | pending | §6, §8.5 | perplexity §8.5 (new; was Phase-16 "out of scope") | `src/assistant/a2a/` — server.py, task_handler.py, agent_card.py. Exposes `/a2a/v1/message:stream` endpoint. Serves `.well-known/agent.json`. Lets Copilot Studio Chief of Staff delegate to this assistant. **Scope expansion per SPI framing analysis**: also the inter-persona bridge for cross-deployment delegation within the user's own ecosystem (personal-process ↔ work-process); includes client side (this assistant delegating to remote A2A endpoints, including its own other-persona deployments). |
 | P7 | `scheduler` | phase | pending | §2.1, §8.6 | perplexity §8.6 (new) | `core/scheduler.py` — cron (croniter) + calendar-event + polling triggers. `schedules:` section in `persona.yaml`. `--daemon` CLI flag. Morning briefing / email triage / pre-meeting brief hooks |
 | P8 | `obsidian-vault` | phase | pending | §2.2, §8.7 | perplexity §8.7 (new) | Bi-directional Obsidian vault sync, split by authoring domain. Vault config declares `notes_dir` (human-authored: frameworks, meeting notes, raw thoughts — synced **into** ACA as indexed source) and `agent_dir` (agent-authored: entity hub pages, compiled summaries — rendered **from** ACA; frontmatter declares `agent_maintained: true`, `compiled_from: <entity_id>`, `regenerated_at: <ts>`; hand-edits may be overwritten on regeneration). Preferred: two endpoints on `agentic-content-analyzer` (`/index/vault-notes` for inbound, `/render/agent-folder` for outbound) invoked by a persona extension. Fallback: standalone `extensions/obsidian.py` with wikilink parsing + pgvector index covers the `notes_dir → ACA` direction only; `agent_dir` rendering deferred until ACA endpoint exists. Headless personas (no vault) skip both directions without penalty. Doctrine/frameworks remain in the persona submodule (loaded via P1.8 `ContextProvider`) — explicitly **not** vault content. |
 | P9 | `error-resilience` | phase | **archived** (2026-05-04) | §1.3, §8.8 | perplexity §8.8 (new) | `core/resilience.py` — `tenacity`-based retry on transient HTTP failures, circuit breaker per backend, graceful degradation (agent notes unavailability instead of silent omission). Applied to http_tools client + extension `health_check()` |
 | P10 | `extension-lifecycle` | phase | pending | §3.1, §8.9 | perplexity §8.9 (new) | Extend `Extension` protocol with `initialize()`, `shutdown()`, `refresh_credentials()` lifecycle hooks. `PersonaRegistry.load_extensions()` calls `initialize()` post-load; registers shutdown handler |
-| P11 | `harness-routing` | phase | pending | §3.2, §8.10 | perplexity §8.10 (new) | Dynamic harness selection in `harnesses/factory.py`. `--harness auto` default. Routes M365-tool tasks → MS Agent Framework, complex reasoning → Deep Agents |
-| P12 | `delegation-context` | phase | pending | §3.3, §5 P1, §8.11 | perplexity §8.11 + old P8 + §5 P1 router | `DelegationContext` dataclass (parent_role, delegation_chain, memory_snippets, conversation_summary, constraints). Cycle detection. `delegate_parallel`. Monitoring/cancellation. Delegation analytics tables. **Includes `delegation/router.py` intent-classification logic** for automatic delegation routing (perplexity §5 P1 item; was missing from v2 scope) |
-| P13 | `security-hardening` | phase | pending | §4, §8.12 | perplexity §8.12 (new) | Per-persona env var scoping in `_env()` helper. Per-persona `.env` files. Extension `manifest.yaml` with SHA-256 hashes verified before `spec.loader.exec_module()` |
-| P14 | `google-extensions` | phase | pending | — | original P4 | Real `gmail`, `gcal`, `gdrive` extension implementations. OAuth refresh via the P10 lifecycle hooks |
-| P15 | `work-persona-config` | phase | pending | — | original P6 | Create `assistant-config-work` submodule, wire into `.gitmodules`, populate work persona config + role overrides. Deferred until work machine available |
-| P16 | `cli-harness-integrations` | phase | pending | — | original P7 | Deeper Claude Code / Codex / Gemini integrations — slash commands in `.claude/commands/`, `.codex/skills/`, `.gemini/settings.json`. Persona-aware routing |
-| P17 | `mcp-server-exposure` | phase | pending | — | original P9 | Expose the assistant as an MCP server so other Claude Code sessions can invoke it as a tool. Complementary to P6 A2A (different protocols, different clients) |
-| P18 | `railway-deployment` | phase | pending | — | original P10 | Run persona instances as Railway services + deployment manifests |
+| P11 | `harness-routing` | phase | pending | §3.2, §8.10 | perplexity §8.10 (new) | Dynamic harness selection in `harnesses/factory.py`. `--harness auto` default. Routes M365-tool tasks → MS Agent Framework, complex reasoning → Deep Agents. **Framing per SPI analysis**: routing is *intra-persona* — selection is among the harnesses the persona's binding manifest (P5.5) declares. Binding validator gates which harnesses are eligible |
+| P12 | `delegation-context` | phase | pending | §3.3, §5 P1, §8.11 | perplexity §8.11 + old P8 + §5 P1 router | `DelegationContext` dataclass (parent_role, delegation_chain, memory_snippets, conversation_summary, constraints). Cycle detection. `delegate_parallel`. Monitoring/cancellation. Delegation analytics tables. **Includes `delegation/router.py` intent-classification logic** for automatic delegation routing (perplexity §5 P1 item; was missing from v2 scope). **Framing per SPI analysis**: explicitly *same-persona, same-process*. Cross-persona delegation is P6 A2A, not delegation-context |
+| P13 | `security-hardening` | phase | pending | §4, §8.12 | perplexity §8.12 (new) | Extension `manifest.yaml` with SHA-256 hashes verified before `spec.loader.exec_module()` (single-persona concern: preventing malicious extension code in your own process). **Scope reduction per SPI analysis**: the original "per-persona env var scoping in `_env()`" and "per-persona `.env` files" items are dropped — they solved a multi-tenant problem that doesn't exist under git-as-multi-tenancy. Each persona deployment is its own process and inherits its own env directly |
+| P14 | `google-extensions` | phase | pending | — | original P4 | Real `gmail`, `gcal`, `gdrive` extension implementations. OAuth refresh via the P10 lifecycle hooks. **Dependency added per SPI analysis**: conformance via P5.7 conformance-test-harness |
+| P14.5 | `persona-deployment-kit` | phase | pending | — | new (SPI framing follow-up) | Reusable scaffolding for new persona deployments: DB provisioning script, vault provisioning, submodule template (extends existing `scripts/init-persona-repo.sh`), `binding.yaml` scaffold, secrets bootstrap, observability sink config, satisfiability health check (runs `assistant binding check`). Depends on P5.5 binding-manifest. Makes P15 a thin "use the kit" PR rather than carrying all the deployment R&D itself |
+| P15 | `work-persona-deployment` (formerly `work-persona-config`) | phase | pending | — | original P6 (renamed per SPI framing) | Stand up the work persona deployment: create `assistant-config-work` submodule, wire into `.gitmodules`, populate work persona config + role overrides + `binding.yaml`. Uses P14.5 deployment kit. Deferred until work machine available. Per SPI analysis: framed as a *deployment event* (new bound process), not "configure multi-tenancy" |
+| P16 | `cli-harness-integrations` | phase | pending | — | original P7 | Deeper Claude Code / Codex / Gemini integrations — slash commands in `.claude/commands/`, `.codex/skills/`, `.gemini/settings.json`. **Framing per SPI analysis**: each CLI integration is a projection of the persona's binding into another runtime's discovery format; the `HostHarnessAdapter` (P1.8) is the right home; persona-aware routing is per-binding-manifest |
+| P17 | `mcp-server-exposure` | phase | pending | — | original P9 | Expose the assistant as an MCP server so other Claude Code sessions can invoke it as a tool. Complementary to P6 A2A (different protocols, different clients). **Dependency added per SPI analysis**: benefits from P5.6 capability-registry's MCP projection layer |
+| P18 | `persona-deployment-runtime` (formerly `railway-deployment`) | phase | pending | — | original P10 (renamed per SPI framing) | Operational expression of git-as-multi-tenancy: run each persona instance as its own deployment (Railway service or equivalent), with deployment manifests, secrets management, observability sink wiring, A2A endpoint exposure. Renamed from `railway-deployment` because the substance is "each persona = one deployment unit," not Railway-specific. Depends on P14.5 (kit) + P15 (first deployment user) + P16 |
 | X1 | `add-teacher-role` | non-phase (feature) | archived 2026-05-15 | — | user-requested (2026-04-16) | Add `teacher` role with Feynman + Socratic skill files; `--method` CLI flag and `/method` / `/methods` REPL commands; declare `content_analyzer:*` preferred tools that bind via the archived P3 http-tools layer once ACA aligns its operationIds. Independent of the P-phase DAG. Followups: ACA#421 (operationIds), assistant#31 (observability), #32 (role-params abstraction when N≥2 roles), #33 (persona-scoped LLM auth). |
 
 ## Status lifecycle
@@ -97,13 +103,35 @@ P1 bootstrap-vertical-slice (archived)
  │                            │                          └─→ P14 google-extensions    (gmail/gcal/gdrive)
  │                            └─→ P9 error-resilience     (retries applied to http_tools client)
  │
- ├─→ P10 extension-lifecycle ─→ P13 security-hardening  (manifest validation uses lifecycle hook)
- └─→ P5 ms-graph-extension    ─→ P11 harness-routing    (routes M365 tasks once MS Agent Framework is real)
+ ├─→ P10 extension-lifecycle ─→ P13 security-hardening  (manifest validation uses lifecycle hook;
+ │                                                       env-scoping scope reduced per SPI analysis)
+ └─→ P5 ms-graph-extension    ─→ P11 harness-routing    (routes M365 tasks once MS Agent Framework is real;
+                                                         intra-persona only — binding manifest declares
+                                                         eligible harnesses)
+
+# SPI framing follow-up phases (new per docs/architecture/)
+P2 + P3 + P5 (archived)
+ └─→ P5.5 binding-manifest  (declarative deployment artifact + validator;
+     │                       breaks MemoryManager persona-param leak)
+     ├─→ P5.6 capability-registry   (unifies HttpToolRegistry + extensions + MCP;
+     │                               replaces Extension dual-surface)
+     │    ├─→ P5.8 pi-harness        (consumes MCP projection)
+     │    └─→ P17 mcp-server-exposure (benefits from MCP projection layer)
+     ├─→ P5.7 conformance-test-harness  (gates Experimental→Provisional promotion;
+     │    │                              required-before for new providers)
+     │    ├─→ P5.8 pi-harness          (conformance against capability-registry contract)
+     │    └─→ P14 google-extensions    (conformance against MemoryManager / Extension)
+     ├─→ P5.9 interface-stability-ci-gate  (small tooling; CI check on ledger drift)
+     ├─→ P14.5 persona-deployment-kit  (scaffolding; depends on binding manifest schema)
+     │    └─→ P15 work-persona-deployment  (first kit consumer)
+     │         └─→ P18 persona-deployment-runtime  (operationalizes per-persona deploy)
+     └─→ P11 harness-routing  (binding validator gates eligible harnesses)
 
 # Independent / long-range
-P15 work-persona-config       needs P5 + P8; also triggered by machine availability
-P17 mcp-server-exposure       needs P6 (protocol parallel; A2A and MCP expose the same assistant)
-P18 railway-deployment        needs P15, P16
+P15 work-persona-deployment   needs P5 + P8 + P14.5 (deployment kit); also triggered by machine availability
+P17 mcp-server-exposure       needs P6 (protocol parallel; A2A and MCP expose the same assistant);
+                              additionally benefits from P5.6 capability-registry's MCP projection
+P18 persona-deployment-runtime needs P14.5, P15, P16
 ```
 
 ## Phase-by-phase execution via autopilot
@@ -131,16 +159,33 @@ re-prefix with dates; the roadmap is the identity source.
 | Theme | Phases that touch it |
 |-------|----------------------|
 | **Capability protocols** (guardrails, sandbox, memory policy, tool policy — harness architecture) | P1.8 establishes protocols; P2 implements MemoryPolicy; P3 implements ToolPolicy; P13 implements GuardrailProvider; P11/P16 consume CapabilityResolver |
-| **Memory hierarchy** (memory.md derived from Postgres+Graphiti — perplexity §1.2) | P2 establishes; P7/P8/P12 consume |
+| **Memory hierarchy** (memory.md derived from Postgres+Graphiti — perplexity §1.2) | P2 establishes; P5.5 cleans up persona-param leak; P7/P8/P12 consume |
 | **Observability** (tracing, cost per persona×role — §1.1) | P4 establishes; all later phases add spans to their new code paths |
 | **Resilience** (retry, circuit breaker — §1.3) | P9 establishes; P3/P5/P14/P17 adopt |
-| **Security boundaries** (credential scoping, manifest validation — §4) | P13 establishes; all phases loading config must comply |
+| **Security boundaries** (credential scoping, manifest validation — §4) | P13 establishes (scope reduced per SPI analysis); all phases loading config must comply |
 | **Proactive execution** (scheduler + A2A + Obsidian RAG — §2) | P6/P7/P8 — the differentiated Chief-of-Staff story |
+| **SPI / binding architecture** (git-as-multi-tenancy → primitives as interfaces, providers selected per deployment via binding manifest — see `docs/architecture/`) | P5.5 binding-manifest establishes; P5.6 capability-registry, P5.7 conformance-test-harness, P5.8 pi-harness, P5.9 ci-gate, P14.5 deployment-kit consume; P15/P18 are deployment-event applications of the framework |
+| **Per-deployment topology** (each persona = one deployment unit; git access control + filesystem + process boundaries enforce isolation, not application code) | P5.5 makes deployment declarative; P14.5 makes deployment reproducible; P15 is the first second-persona deployment; P18 operationalizes per-persona services |
 
 ## Out of scope for roadmap v2
 
-Items from bootstrap spec Phase 16 not adopted by perplexity §8 and
-still deferred: cross-persona bridge, multi-model routing (beyond the
-harness-routing in P11), role learning, persona config encryption,
-NotebookLM integration. Each may re-enter a future v3 roadmap if
+Items from bootstrap spec Phase 16 not adopted by perplexity §8.
+Amended per SPI framing analysis (see `docs/architecture/`):
+
+- **Cross-persona bridge** — no longer out of scope; reframed under
+  P6 a2a-server (scope expanded to include inter-persona delegation
+  between the user's own deployments).
+- **Persona config encryption** — explicit non-goal (not a deferral).
+  Git access control on private persona submodules is the chosen
+  encryption mechanism; per-persona deployment topology is the
+  chosen isolation mechanism. Adding application-layer encryption
+  would duplicate what git + filesystem + process boundaries
+  already provide under git-as-multi-tenancy.
+- **Multi-model routing** (beyond the harness-routing in P11) —
+  remains deferred; revisit when a persona's binding manifest
+  declares multiple model providers.
+- **Role learning** — remains deferred.
+- **NotebookLM integration** — remains deferred.
+
+Each remaining deferred item may re-enter a future v3 roadmap if
 perplexity-equivalent review surfaces demand.


### PR DESCRIPTION
First-draft architectural statement and per-interface stability ledger.

primitives-and-providers.md frames the repo as an SPI over agent
primitives (models, harness, tools, memory, identity, sessions,
observability, sandboxes, agent registry, skills) with
persona-as-config-bundle selecting providers per primitive. Narrows
the load-bearing novelty claim to public-code + private-config
submodules + the two-layer privacy guard. Names cross-cutting concerns
the matrix hides, role-portability caveats, and the binding-shaped vs
migration-shaped distinction.

interface-stability.md classifies each repo-owned interface
(Stable / Provisional / Experimental / Pre-interface), records
semantic conformance gaps alongside known leaks, defines the local-vs
-managed conformance tier split for CI feasibility, and enumerates
cross-primitive compatibility groups as binding-validator constraints.