### PR TITLE
Add architecture ledger drift check, memory persona binding, docs, and conformance tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Ruff
         run: uv run ruff check .
 
+      - name: Architecture ledger drift gate
+        run: python scripts/check-architecture-ledger-drift.py
+
       - name: Mypy
         run: uv run mypy src tests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Ruff
         run: uv run ruff check .
 
+      - name: Architecture ledger drift gate
+        run: python scripts/check-architecture-ledger-drift.py
+
       - name: Mypy
         run: uv run mypy src tests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+          # Full history: the architecture ledger drift gate diffs against
+          # the merge base with the base branch. The default fetch-depth: 1
+          # is a single-commit shallow clone where even HEAD~1 does not
+          # resolve, so the gate cannot compute a range.
+          fetch-depth: 0
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -693,6 +693,7 @@ that waste the most time:
 | G6 | Private-persona content leaking into public tests | Use `FIXTURE_PERSONA_SENTINEL_v1` assertions; never hard-code `personas/personal/` strings; trust the two-layer guard |
 | G7 | Submodule standalone tests silent-skip when parent `roles/` is absent | Default is strict fail; opt in with `ALLOW_STANDALONE_SUBMODULE_SKIP=1` when running the submodule in isolation |
 | G8 | Local `mypy src/` passes but CI `mypy src tests` fails on test-side narrowing errors | Always run the full CI scope locally (`uv run mypy src tests`) before pushing — see Landing the Plane quality gates |
+| G9 | CI blocks on the architecture-ledger drift gate after touching `harnesses/`, `extensions/`, `core/memory*`, or `telemetry/` | Update a `docs/architecture/` ledger file, or declare a non-interface change with `[skip-ledger: <reason>]` in a commit message — see "Architecture Ledger Drift Gate" |
 
 ## What's Not Yet Wired
 
@@ -786,6 +787,42 @@ browse with `gh issue list --label followup`:
   - #18 — `assistant export` should run `discover_tools` for host-harness manifests
   - #19 — detect parameter/body name collisions in `_build_args_schema`
 
+## Architecture Ledger Drift Gate
+
+CI runs a **blocking** gate (`scripts/check-architecture-ledger-drift.py`,
+between Ruff and Mypy in `.github/workflows/ci.yml`) that fails when a
+change touches an interface-bearing path **without** updating the
+architecture ledger. The goal is to keep interface changes captured in one
+reviewable place. Watched prefixes:
+
+- `src/assistant/harnesses/`
+- `src/assistant/extensions/`
+- `src/assistant/core/memory*`
+- `src/assistant/telemetry/`
+
+Ledger files (updating **either** satisfies the gate):
+`docs/architecture/interface-stability.md`,
+`docs/architecture/primitives-and-providers.md`.
+
+**When you change a watched path, do ONE of:**
+
+1. Record the interface change in a ledger file (the intended path — a real
+   entry describing what changed), OR
+2. If the change is genuinely NOT an interface change (bugfix, comment,
+   internal refactor under a watched dir), declare it with a marker in any
+   commit message on the branch: `[skip-ledger: <reason>]` (reason
+   required, non-empty). The bypass is logged in CI and visible in history —
+   it is a reviewable declaration, not a silent whitespace edit.
+
+The gate diffs against the merge base with `origin/main` and needs full
+history (`fetch-depth: 0` in CI). Run it locally with
+`python scripts/check-architecture-ledger-drift.py --base origin/main`.
+
+**Dispatch briefs MUST list this gate** in their Verification section when
+the work touches a watched path — otherwise dispatched agents will report
+green while CI blocks on a missing ledger update (see the "dispatch briefs
+must list every CI gate" lesson).
+
 ## Landing the Plane (Session Completion)
 
 **When ending a work session**, complete ALL steps below. Work is NOT
@@ -796,6 +833,8 @@ complete until `git push` succeeds.
    - `uv run pytest tests/`
    - `uv run ruff check src tests`
    - `uv run mypy src tests`  (CI runs the broader scope; `mypy src/` alone misses test-side errors)
+   - `python scripts/check-architecture-ledger-drift.py --base origin/main`
+     (**blocking gate** — see below; only fires when interface-bearing paths change)
    - `openspec validate --strict` if OpenSpec artifacts changed
 3. **Update issue / OpenSpec status** — close finished, annotate in-progress
 4. **PUSH TO REMOTE** — mandatory:

--- a/docs/architecture/compatibility-groups.yaml
+++ b/docs/architecture/compatibility-groups.yaml
@@ -1,0 +1,25 @@
+groups:
+  - name: interrupt_resume
+    requires:
+      - primitive: HarnessAdapter
+        capability: interrupt_resume
+      - primitive: SessionStore
+        capability: checkpointing
+      - primitive: MemoryManager
+        capability: replay_safe
+  - name: tool_streaming
+    requires:
+      - primitive: HarnessAdapter
+        capability: streaming
+      - primitive: CapabilityRegistry
+        capability: projection_streaming
+      - primitive: Observability
+        capability: stream_span_propagation
+  - name: cross_persona_audit
+    requires:
+      - primitive: IdentityProvider
+        capability: audit_trail
+      - primitive: Observability
+        capability: retention
+      - primitive: MemoryManager
+        capability: forget

--- a/docs/architecture/contracts/capability-registry-v1.yaml
+++ b/docs/architecture/contracts/capability-registry-v1.yaml
@@ -1,0 +1,21 @@
+version: 1
+canonical_form: openapi-3.1
+extensions:
+  - x-aa-streaming
+  - x-aa-roles
+  - x-aa-auth
+capability_kinds:
+  - tool
+  - skill
+  - agent
+required_fields:
+  - id
+  - kind
+  - name
+  - description
+  - projection_targets
+projection_targets:
+  - langchain
+  - msaf
+  - mcp
+  - cli

--- a/docs/architecture/interface-stability.md
+++ b/docs/architecture/interface-stability.md
@@ -490,10 +490,10 @@ mitigations, in increasing strength:
    `src/assistant/core/memory*` (when added),
    `src/assistant/telemetry/`, or related interface files must touch
    the corresponding ledger entry. Reviewers reject PRs that don't.
-2. **CI gate (planned):** a check that fails the build when an
-   interface-bearing file is modified without a corresponding
-   ledger touch. Implementation deferred; the obligation in (1) is
-   the working agreement until the gate lands.
+2. **CI gate (implemented):** `scripts/check-architecture-ledger-drift.py`
+   fails when interface-bearing files change without touching
+   `docs/architecture/interface-stability.md` or
+   `docs/architecture/primitives-and-providers.md`.
 
 The ledger is meant to be edited frequently. A stale entry is worse
 than a missing one — it silently lies to consumers about what they

--- a/docs/architecture/interface-stability.md
+++ b/docs/architecture/interface-stability.md
@@ -13,6 +13,39 @@ The ledger changes more often than the primitives document. Treat
 exists, why) and this document as the **status** statement (what's
 solid, what's drifting, what's open).
 
+## Baseline reconciliation (2026-07-22)
+
+This ledger was first written ~2026-05-16 and then stranded for two
+months when a revert removed it from the tree. It has been reconciled
+against everything that landed since (P5 through P30). Material state
+changes folded in:
+
+- **`Extension` protocol** — the `as_langchain_tools()` /
+  `as_ms_agent_tools()` dual surface (the ledger's flagship "leaked
+  interface" example) was **removed** in P17 `mcp-server-exposure` and
+  replaced with `tool_specs() -> list[ToolSpec]`. The leak is resolved,
+  not pending.
+- **`MemoryManager` persona parameter** — no longer "a relic to drop
+  in binding-manifest." Methods now take `persona: str | None`, the
+  manager can be **bound at construction** (`persona_name`), and it
+  **raises on a persona mismatch** rather than silently honouring
+  either side.
+- **`HarnessAdapter`** — streaming is realized (`astream_invoke ->
+  AsyncIterator[HarnessEvent]`, P14a); `spawn_sub_agent` gained the
+  additive `context: DelegationContext | None` parameter (P12); MSAF is
+  a real provider, not a stub (P5).
+- **`ModelProvider` / `ModelRef`** — a new realized interface (P19
+  `model-provider-routing`, seam #6 in P24) that did not exist when the
+  ledger was written. New entry below.
+- **`SessionStore`** — durable sessions landed (P30 `durable-sessions`
+  + the P24 checkpointer contract). Promoted off Pre-interface.
+
+Entries left intentionally untouched (still accurate as
+Pre-interface/proposed): `CapabilityRegistry`, `IdentityProvider`,
+`Sandbox`, `AgentRegistry`, `SkillResolver`. Their open questions are
+unchanged; only `CredentialProvider` progress (P13/P24/P25) is noted
+inline under `IdentityProvider`.
+
 ## Stability levels
 
 | Level | Meaning | When to use it | When to graduate |
@@ -118,83 +151,118 @@ Each entry below follows the same template:
 
 ### `HarnessAdapter` and tier subclasses
 
-- **Code:** `src/assistant/harnesses/base.py:12, 24, 48`
+- **Code:** `src/assistant/harnesses/base.py:20` (`HarnessAdapter`),
+  `:32` (`SdkHarnessAdapter`), `:157` (`HostHarnessAdapter`)
 - **Stability:** **Experimental** (downgrade candidate from earlier
   implicit "Provisional" — design will change as `AgentRegistry` and
   `CapabilityRegistry` land)
 - **Semantic conformance points (currently unspecified — gaps):**
   - What does `invoke()` returning `str` *mean* when the model produced
-    multi-block content (text + citations + tool traces)? Not specified.
+    multi-block content (text + citations + tool traces)? Not specified
+    for the sync path — but `astream_invoke()` (below) now gives the
+    structured alternative for consumers that need it.
   - What guarantees does `spawn_sub_agent()` give about isolation (does
     the child share memory state? identity tokens? span context)? Not
     specified.
   - When does `create_agent` finish — after the LLM is reachable, after
     the first system prompt is loaded, after tools are bound? Not
     specified. Each adapter currently chooses.
-- **Capability semantics needed (not yet declared):**
-  `streaming`, `interrupt_resume`, `multi_agent_native`, `plan_mode`,
+- **Realized capability semantics:**
+  - **`streaming`** — `astream_invoke(agent, message) ->
+    AsyncIterator[HarnessEvent]` (`base.py:72`, P14a
+    `harness-ag-ui-bridge`). Contract: begins with `RunStarted`, yields
+    `TextDelta` / `ToolCall*` events, ends with `RunFinished`
+    (two-phase error contract). No longer an open question — it is
+    implemented and consumed by the AG-UI SSE transport.
+  - **`delegation context`** — `spawn_sub_agent` takes an additive
+    `context: DelegationContext | None = None` (`base.py:101`, P12
+    `delegation-context`); `None` preserves pre-P12 behaviour exactly.
+- **Capability semantics still needed (not yet declared):**
+  `interrupt_resume`, `multi_agent_native`, `plan_mode`,
   `parallel_tool_calls`, `structured_output`.
 - **Providers:**
   - `DeepAgentsHarness` (LangGraph) — `src/assistant/harnesses/sdk/deep_agents.py`
-  - `MSAgentFrameworkHarness` (stub → real in P5) —
-    `src/assistant/harnesses/sdk/ms_agent_fw.py`
+  - `MSAgentFrameworkHarness` (**real**, P5 `ms-graph-extension`
+    archived) — `src/assistant/harnesses/sdk/ms_agent_fw.py`
+  - `ClaudeCodeHarness` (Host tier, P1.8 `capability-protocols`) —
+    exports config rather than executing
   - Pi harness — proposed, not yet implemented
-- **Conformance suite:** not yet — current tests are per-harness, not
-  cross-harness. A `tests/conformance/test_harness_adapter.py` covering
-  `name()`, `harness_type()`, `create_agent()`, `invoke()`, and
-  `spawn_sub_agent()` against a mock persona/role/tool fixture is
-  prerequisite to a second non-stub implementation.
+- **Conformance suite:** **exists** —
+  `tests/conformance/test_harness_adapter.py` covers `name()`,
+  `harness_type()`, `create_agent()`, `invoke()`, and `spawn_sub_agent()`
+  (including the P12 `context` parameter) against fixture persona/role.
+  Cross-provider (DeepAgents vs MSAF) semantic conformance is still
+  per-harness; a shared behavioural suite is the next step toward
+  Provisional.
 - **Known leaks:**
-  - `spawn_sub_agent()` returns a `str` (`base.py:39-45`), assuming a
-    single text reply. Sub-agent results may legitimately be structured
-    (citations, tool traces, plan deltas). Move to a typed result envelope
-    once a second harness exercises this path.
+  - `invoke()` / `spawn_sub_agent()` return a `str`, assuming a single
+    text reply. Sub-agent results may legitimately be structured
+    (citations, tool traces, plan deltas). `astream_invoke` addresses
+    this for the streaming path; the sync path still flattens. Move to a
+    typed result envelope once a second harness exercises the structured
+    path.
   - `create_agent()`'s `tools` and `extensions` arguments are
-    `list[Any]` (`base.py:31-33`) — the protocol doesn't constrain shape.
-    This will tighten once `CapabilityRegistry` is the discovery source.
+    `list[Any]` — the protocol doesn't constrain shape. Note that tools
+    are now the harness-neutral `ToolSpec` (P17) rendered per-harness by
+    `harnesses/tool_adapters.py`; the annotation should tighten to
+    `list[ToolSpec]` when `CapabilityRegistry` becomes the discovery
+    source.
   - `spawn_sub_agent()` lives on the harness at all — should move to
-    `AgentRegistry` once that primitive exists.
+    `AgentRegistry` once that primitive exists. The current
+    implementation constructs a same-type child, blocking cross-harness
+    delegation (see `AgentRegistry` entry).
 - **Open questions:**
-  - Streaming surface: `invoke()` is sync-shaped (`str` return). Should it
-    return `AsyncIterator[Event]` instead? Likely yes; deferred until a
-    consumer needs streaming (the CLI doesn't yet).
   - Cancellation / interrupt: no method today; LangGraph and Pi both
-    support it natively. Add when needed.
-  - Memory wiring: today each adapter wires its own memory (DeepAgents
-    via `InMemorySaver`, MSAF via prepend). After `MemoryManager` lands,
-    adapters consume from it; the interface should declare a `memory`
-    constructor parameter.
+    support it natively. The P24 approval interrupt/resume contract and
+    P30 durable sessions provide the checkpoint substrate; a harness-level
+    cancel/interrupt surface is still unshaped.
+  - Memory wiring: DeepAgents wires session memory via the P30
+    checkpointer (`harnesses/sdk/checkpointer.py`), MSAF via minimal
+    prepend (D27). The interface still does not declare a `memory`
+    constructor parameter; wiring remains per-adapter.
 
 ---
 
 ### `Extension` protocol
 
-- **Code:** `src/assistant/extensions/base.py:15`
-- **Stability:** **Provisional** (with a known deprecation path)
+- **Code:** `src/assistant/extensions/base.py:66` (`tool_specs`), `:68`
+  (`health_check`)
+- **Stability:** **Provisional** (the flagship leak below is now
+  resolved; holding at Provisional pending a conformance suite and a
+  second real provider family — Google — landing)
+- **Protocol shape (P17 `mcp-server-exposure`):** `name` +
+  `tool_specs() -> list[ToolSpec]` + `health_check() -> HealthStatus`.
+  Since P10 `extension-lifecycle`, extensions may also implement optional
+  async hooks `initialize()` / `shutdown()` / `refresh_credentials()` —
+  NOT required Protocol members, so private structural extensions stay
+  compatible; subclass `ExtensionBase` for no-op defaults.
 - **Providers:**
-  - Empty-tool stubs for `ms_graph`, `teams`, `sharepoint`, `outlook`,
-    `gmail`, `gcal`, `gdrive` (`src/assistant/extensions/`)
-  - Real MS extensions arrive in `ms-graph-extension` phase (P5)
-  - Real Google extensions arrive in `google-extensions` phase
+  - Real MS extensions (`ms_graph`, `outlook`, `teams`, `sharepoint`) —
+    shipped, P5 `ms-graph-extension` archived (code only; disabled on
+    `personal` until the work persona lands, P15)
+  - Empty-tool stubs for `gmail`, `gcal`, `gdrive` — real Google
+    extensions arrive in the `google-extensions` phase
 - **Conformance suite:** not yet — extension health checks are
   per-extension. A `tests/conformance/test_extension.py` covering
-  `name`, `health_check()`, and the future `register()` is owed.
-- **Known leaks (load-bearing):**
-  - **Dual-surface methods** `as_langchain_tools()` and
-    `as_ms_agent_tools()` (`base.py:19-21`) bake consumer identity into
-    the protocol. Adding a Pi consumer requires either a third method
-    (`as_pi_tools()`) or a refactor. Refactor is the right move: replace
-    with `register(registry: CapabilityRegistry, persona: PersonaConfig)`
-    once `CapabilityRegistry` exists. This is the cleanest example in the
-    repo of a leaked interface.
+  `name`, `tool_specs()`, and `health_check()` is owed.
+- **Resolved leak (was the repo's flagship example):**
+  - The **dual-surface methods** `as_langchain_tools()` and
+    `as_ms_agent_tools()` that baked consumer identity into the protocol
+    were **REMOVED** in P17 (tool-spec exit criterion, no shim retained).
+    Extensions now emit the harness-neutral, MCP-shaped `ToolSpec`
+    (`core/toolspec.py`); harnesses render it through per-harness
+    adapters in `harnesses/tool_adapters.py` (LangChain `StructuredTool`,
+    MSAF `FunctionTool`, `mcp.types.Tool`) and never derive tools from
+    extensions directly. Adding a Pi consumer is now a new adapter, not a
+    new protocol method.
 - **Open questions:**
-  - What does `register()` accept exactly? OpenAPI specs? Pure JSON
-    Schema + handler references that the registry wraps into OpenAPI?
-    Both? Resolution comes with the `CapabilityRegistry` design.
   - Should extensions declare their persona-affinity (e.g. "this
     extension is only for `work`") at the protocol level, or via
-    persona-side config? Lean toward the latter to keep the protocol
-    persona-agnostic.
+    persona-side config? Currently the latter (activation config lives in
+    private persona repos), keeping the protocol persona-agnostic.
+  - The relationship between `ToolSpec` (per-extension emission) and the
+    unified `CapabilityRegistry` (proposed) — the registry would become
+    the aggregation/projection layer over what extensions already emit.
 
 ---
 
@@ -211,10 +279,12 @@ Each entry below follows the same template:
 - **Providers:**
   - `HttpToolRegistry` — partial implementation, current; four open
     follow-ups (#16–#19 in archived `http-tools-layer`)
-  - Extensions exposed via `as_langchain_tools()` /
-    `as_ms_agent_tools()` — current dual-surface pattern to be
-    replaced
-  - Self-hosted MCP gateway — planned projection target
+  - Extensions exposed via `tool_specs() -> list[ToolSpec]` (P17); the
+    per-harness rendering that used to be the dual-surface pattern now
+    lives in `harnesses/tool_adapters.py`. A unified registry would
+    aggregate these `ToolSpec`s rather than call extensions per consumer.
+  - Self-hosted MCP gateway — planned projection target (P17 already
+    exposes the MCP surface at `/mcp`)
   - CLI projection (`assistant tool …`) — partial today via
     `--list-tools`
   - AgentCore Gateway — slot-compatible if the canonical form is
@@ -264,17 +334,25 @@ Each entry below follows the same template:
 - **Conformance suite:** not yet — `MemoryPolicy` has tests but no
   cross-provider conformance harness exists. Required before lifting
   to Provisional.
-- **Known leaks (load-bearing):**
-  - **Persona parameter on methods.** `get_context(persona, role, …)`,
-    `store_fact(persona, key, value)`, `store_interaction(persona, …)`,
-    and similar methods accept a `persona: str` parameter
-    (`memory.py:30, 65, etc.`). Under git-as-multi-tenancy this is
-    leakage — each instance is already persona-bound at construction
-    via the `session_factory`; the method parameter is a relic of a
-    multi-tenant assumption that doesn't apply (see
-    `primitives-and-providers.md` → "Privacy boundary"). Cleanup
-    folds into the `binding-manifest` phase: drop the parameter, the
-    instance is the persona's manager.
+- **Persona parameter — partially resolved (was a load-bearing leak):**
+  - `get_context`, `store_fact`, `store_interaction`, `store_episode`,
+    `search`, and `export_memory` now take `persona: str | None`
+    (`memory.py:32` `_resolve_persona`). A manager can be **bound at
+    construction** via `persona_name` (as `PostgresGraphitiMemoryPolicy`
+    does), after which callers pass `None` and the instance resolves its
+    own persona. This directly addresses the git-as-multi-tenancy
+    critique: the instance already knows its persona, so the caller need
+    not supply it.
+  - **The binding is now enforced, not just convenient.**
+    `_resolve_persona` **raises** if an explicit persona is passed that
+    differs from the bound one — a bound manager refuses to operate on
+    another persona rather than silently honouring either side. Unbound
+    managers (the CLI/host construction sites) still require an explicit
+    persona, so there is no regression there.
+  - Remaining work: the parameter has not been *dropped* — it is
+    optional. Fully removing it (making the instance the sole source of
+    truth) still folds into the `binding-manifest` phase; the current
+    optional-and-validated shape is the safe intermediate.
   - The MSAF "minimal-prepend" pattern (D27) treats memory as a
     read-only context source. The full interface supports
     write-through and async ingestion; the minimal-prepend pattern is
@@ -307,11 +385,53 @@ Each entry below follows the same template:
 
 ---
 
+### `ModelProvider` / `ModelRef`
+
+- **Code:** `src/assistant/core/capabilities/models.py` (`ModelRef`,
+  registry, capability tags), `capabilities/model_bindings.py`
+  (per-consumer bindings), `capabilities/health.py`. Realized in P19
+  `model-provider-routing`; contracted as capability slot #6 in P24.
+- **Stability:** **Provisional** (real, cross-consumer bindings exist;
+  the seam is exercised by both SDK harnesses plus direct calls)
+- **Providers:** persona-level `models:` registry — named entries with a
+  provider string (`anthropic:`, `openai:`, `google_genai:`,
+  `google_vertexai:`, `bedrock_converse:`, `ollama:`, OpenRouter via an
+  OpenAI-compatible `base_url`), capability tags (`fast`, `cheap`,
+  `long-context`, `coding`, `vision`, `local-only`, `private-data-ok`),
+  and ordered fallback chains.
+- **Shape:** `core/model_router.py` resolves capability requirements to a
+  harness-neutral `ModelRef`; thin per-consumer bindings adapt it
+  (LangChain `init_chat_model` for DeepAgents, `agent-framework` chat
+  clients for MSAF, a raw OpenAI-compatible client for direct calls such
+  as embeddings/summarization). Per-persona API-key resolution goes
+  through the `CredentialProvider` seam; budget enforcement rides
+  `GuardrailProvider` via `ActionRequest(action_type="model_call")`; cost
+  attribution flows through the existing telemetry spans.
+- **Conformance suite:** binding-level tests exist; a cross-provider
+  `tests/conformance/test_model_provider.py` (resolve → ModelRef →
+  per-binding adaptation) would firm up the Provisional claim.
+- **Known leaks:** the catalog format mirrors the OpenRouter `/models`
+  schema so cloud entries sync verbatim and local entries are
+  hand-authored in the same shape — a deliberate coupling to that schema,
+  noted so a future OpenRouter format change is understood as a breaking
+  input.
+- **Open questions:** the catalog schema + pricing data are shared with
+  `agentic-coding-tools`' cost-aware routing as **contracts, not code**
+  (protocol-standards doc Part C); keeping the two in sync without a
+  published package is an open operational question.
+
+---
+
 ### `IdentityProvider` (proposed)
 
-- **Code:** not yet — `bao-vault` skill exists for OpenBao operations
-  but no agent-facing interface
-- **Stability:** **Pre-interface**
+- **Code:** no unified agent-facing interface yet, but the
+  **`CredentialProvider` seam** now exists (P24 contract 7): one lookup
+  interface for secrets/API keys, with the existing `_env()` indirection
+  as the default impl and an OpenBao backend landing in P25. The
+  `bao-vault` skill covers OpenBao operations at the script level.
+- **Stability:** **Pre-interface** for the broad identity concept;
+  the credential-lookup slice is **Experimental** (seam defined, env
+  impl shipping, OpenBao backend in progress)
 - **Providers:**
   - OpenBao / HashiCorp Vault self-host — primary local provider
   - AgentCore Identity — managed, for `work` if employer is AWS
@@ -337,32 +457,48 @@ Each entry below follows the same template:
 
 ---
 
-### `SessionStore` (proposed)
+### `SessionStore` / `SessionRegistry`
 
-- **Code:** not yet — LangGraph `InMemorySaver` used directly in
-  `harnesses/sdk/deep_agents.py:60`
-- **Stability:** **Pre-interface**
+- **Code:** `src/assistant/harnesses/sessions.py:67` (`SessionRegistry`:
+  create/lookup/resolve/expire by `thread_id`), `:56` (`Session`);
+  `harnesses/sdk/checkpointer.py` (LangGraph checkpointer binding).
+  Realized in P30 `durable-sessions`, contracted in P24
+  `capability-protocols-v2` (seam #5).
+- **Stability:** **Experimental** (real implementation exists for the
+  DeepAgents harness; single-provider, no cross-provider conformance
+  harness yet)
 - **Providers:**
-  - LangGraph `InMemorySaver`, `SqliteSaver`, `PostgresSaver`
-  - Pi `SessionManager` (JSON-L) — interesting because it survives
-    process restarts trivially
-  - AgentCore session state — managed
-  - OpenAI Threads — managed
-- **Conformance suite:** not yet.
+  - LangGraph checkpointer — `InMemorySaver` (default tier) and a
+    **Postgres** durable tier (`sessions: {durable: true}` + database
+    URL; migration 002 adds the durable schema)
+  - `SqliteSaver`, `PostgresSaver` — slot-compatible
+  - Pi `SessionManager` (JSON-L) — survives process restarts trivially
+  - AgentCore session state, OpenAI Threads — managed
+- **Conformance suite:** not yet as a cross-provider harness; the
+  durable tier has direct tests. A `tests/conformance/test_session_store.py`
+  covering create/lookup/resolve/expire is the next step toward
+  Provisional.
 - **Known leaks (design-time):**
-  - LangGraph's `thread_id` is a session-identity concept that not all
-    providers expose. The interface should use an opaque `SessionId`
-    type and let providers map.
+  - LangGraph's `thread_id` is the session-identity concept the registry
+    currently exposes directly. It should become an opaque `SessionId`
+    type that providers map, rather than leaking the LangGraph name.
   - Forking and branching: Pi has it natively; LangGraph supports
     time-travel; managed providers vary. Surface as a capability, not
     a required method.
 - **Open questions:**
-  - Lift this primitive now (force the design with one provider) or
-    wait until a second harness needs the same checkpoint behaviour?
-    Lean toward lift-on-second-consumer to avoid premature abstraction.
+  - The `SessionRegistry` lives under `harnesses/` today; whether it
+    should be a top-level capability alongside `MemoryManager` (so the
+    P7 scheduler and P6 A2A server can multiplex sessions without going
+    through a harness) is unsettled.
   - Relationship to `MemoryManager`: session writes feed memory
-    ingestion. Define the write hook so memory ingestion can subscribe
-    to session writes without each harness re-implementing the bridge.
+    ingestion. The write hook so memory ingestion can subscribe to
+    session writes without each harness re-implementing the bridge is
+    still undefined.
+  - Approval interrupt/resume (P24 seam #6) rides on this checkpoint
+    substrate: a guardrail block checkpoints, suspends, and resumes on an
+    approval decision. The suspend/resume contract is defined but its
+    channel-agnostic surface (AG-UI now; email/messaging later) is still
+    settling.
 
 ---
 
@@ -493,11 +629,19 @@ mitigations, in increasing strength:
 2. **CI gate (implemented):** `scripts/check-architecture-ledger-drift.py`
    fails when interface-bearing files change without touching
    `docs/architecture/interface-stability.md` or
-   `docs/architecture/primitives-and-providers.md`.
+   `docs/architecture/primitives-and-providers.md`. It diffs against the
+   merge base with `origin/main` (so it sees the whole PR, not just the
+   tip commit) and needs full history (`fetch-depth: 0`). A change that
+   is genuinely not an interface change may bypass it by declaring
+   `[skip-ledger: <reason>]` in a commit message — a reviewable
+   declaration in history, printed in the CI log, rather than a token
+   whitespace edit. See CLAUDE.md → "Architecture Ledger Drift Gate".
 
 The ledger is meant to be edited frequently. A stale entry is worse
 than a missing one — it silently lies to consumers about what they
-can depend on.
+can depend on. This baseline was reconciled on 2026-07-22 (see the
+banner at the top); the discipline from here is to keep each entry
+honest per PR rather than let a two-month gap reopen.
 
 ## Open meta-questions
 

--- a/docs/architecture/interface-stability.md
+++ b/docs/architecture/interface-stability.md
@@ -1,0 +1,517 @@
+# Interface Stability Ledger
+
+This document records the current stability classification of every
+repo-owned interface enumerated in
+[`primitives-and-providers.md`](./primitives-and-providers.md). It is the
+discipline that turns the SPI claim from aspiration into a verifiable
+promise: every interface in the table below has a named contract surface,
+a stability level, a conformance test path (or a "not yet" placeholder),
+and a list of known leaks or open design questions.
+
+The ledger changes more often than the primitives document. Treat
+`primitives-and-providers.md` as the **architecture** statement (what
+exists, why) and this document as the **status** statement (what's
+solid, what's drifting, what's open).
+
+## Stability levels
+
+| Level | Meaning | When to use it | When to graduate |
+|---|---|---|---|
+| **Stable** | Interface is well-shaped; ≥2 providers implement it; conformance suite exists and is green; breaking changes require a deprecation cycle | A primitive has matured through real cross-provider use without churn | After two consecutive minor releases without interface-breaking changes |
+| **Provisional** | Interface exists in code; ≥1 provider implements it; conformance suite exists or is being written; breaking changes are still allowed with a clear note | A primitive has been lifted into the repo but the shape is still settling | Promote to Stable after a second provider lands and the conformance suite catches the divergence |
+| **Experimental** | Interface is being designed in code; expect changes per release; no conformance suite yet; consumers must accept the churn | A primitive is being built; the shape is forming through use | Promote to Provisional once the design has settled and a conformance harness is sketched |
+| **Pre-interface** | Concept exists as documentation or aspiration; no interface code yet; behaviour lives inside specific providers and is not portable | A primitive has been identified but the contract has not yet been written | Promote to Experimental when a second consumer forces the design |
+
+The progression is **Pre-interface → Experimental → Provisional → Stable**.
+Demotions happen (and are noted) when a discovered leak forces a redesign.
+
+## Semantic conformance
+
+Signature conformance — does the provider expose the right methods with
+the right argument and return types — is necessary but not sufficient.
+The harder bar is **semantic conformance**: does the provider behave
+the way consumers expect under the cases the interface specifies?
+
+The repo distinguishes:
+
+- **Required semantics** — every provider claiming the interface must
+  honour these. Conformance test failure is a binding-eligibility
+  failure; the provider is not eligible for the primitive slot in any
+  persona.
+- **Capability semantics** — opt-in behaviours providers may advertise
+  via `supports(capability_name) -> bool`. Roles declare requirements;
+  the binding validator (see `primitives-and-providers.md` →
+  "Role portability") rejects persona configurations where a required
+  capability is not supplied.
+- **Provider-specific semantics** — behaviour that intentionally diverges
+  and is documented per provider. A role that depends on this must opt
+  in explicitly and is no longer persona-portable.
+
+Each entry below names known semantic conformance points alongside its
+known leaks. Required semantics that are not yet specified are also
+called out — they are gaps in the contract.
+
+## Conformance against managed providers
+
+A practical constraint that affects every entry: conformance suites
+cannot run end-to-end against managed providers in CI without cloud
+credentials, network access, and spend. The repo's practice is a
+two-tier conformance regime:
+
+- **Local conformance** — runs against real providers in CI on every
+  PR. Local providers (Ollama, LangGraph checkpointers, OpenBao,
+  self-hosted Langfuse, local Postgres + Graphiti) are the conformance
+  baseline.
+- **Managed conformance** — runs in two modes: against mocks of the
+  managed provider in CI on every PR, and against the real managed
+  provider in a periodic verification job (cadence per provider,
+  documented in the entry). Mock drift is a documented risk; periodic
+  verification is the mitigation.
+
+A provider's stability classification depends on which tier it can
+satisfy. A managed provider cannot reach **Stable** without an active,
+green periodic verification job. A managed provider's mock conformance
+can support **Provisional** but does not on its own justify higher.
+
+Conformance is always **per-deployment** (per bound persona), not
+multi-tenant. A provider proves it satisfies the interface for one
+persona at a time. This is a direct consequence of git-as-multi-tenancy
+(see `primitives-and-providers.md` → "What's actually novel"):
+multi-tenant scenarios are not part of the contract, because two
+personas never share a process. Cross-deployment behaviour
+(e.g. one persona delegating to another) is an A2A protocol concern,
+not a provider conformance concern.
+
+## Cross-primitive constraints
+
+Some role requirements span multiple primitives. The binding validator
+must express constraints that involve more than one interface:
+
+- `interrupt_resume` requires harness support **and** session-store
+  checkpoint support **and** memory replay safety.
+- `tool_streaming` requires harness streaming support **and** capability
+  registry projection streaming **and** observability span propagation
+  across stream boundaries.
+- `cross_persona_audit` requires identity provider audit trail **and**
+  observability span retention **and** memory `forget` support
+  consistent with audit constraints.
+
+These are not new primitives — they are **compatibility groups** that
+the binding validator enforces. Each compatibility group has a name,
+an enumeration of (primitive, capability) requirements, and the role
+declarations that consume it. The enumeration lives in this document
+under the relevant entries.
+
+## Per-interface entries
+
+Each entry below follows the same template:
+
+- **Interface name** and code location (file:line if it exists)
+- **Stability** — current level
+- **Providers** — what implements it today
+- **Conformance suite** — path to the shared test file, or "not yet"
+- **Known leaks** — implementation assumptions that have crept into the
+  contract
+- **Open questions** — design decisions still pending
+
+---
+
+### `HarnessAdapter` and tier subclasses
+
+- **Code:** `src/assistant/harnesses/base.py:12, 24, 48`
+- **Stability:** **Experimental** (downgrade candidate from earlier
+  implicit "Provisional" — design will change as `AgentRegistry` and
+  `CapabilityRegistry` land)
+- **Semantic conformance points (currently unspecified — gaps):**
+  - What does `invoke()` returning `str` *mean* when the model produced
+    multi-block content (text + citations + tool traces)? Not specified.
+  - What guarantees does `spawn_sub_agent()` give about isolation (does
+    the child share memory state? identity tokens? span context)? Not
+    specified.
+  - When does `create_agent` finish — after the LLM is reachable, after
+    the first system prompt is loaded, after tools are bound? Not
+    specified. Each adapter currently chooses.
+- **Capability semantics needed (not yet declared):**
+  `streaming`, `interrupt_resume`, `multi_agent_native`, `plan_mode`,
+  `parallel_tool_calls`, `structured_output`.
+- **Providers:**
+  - `DeepAgentsHarness` (LangGraph) — `src/assistant/harnesses/sdk/deep_agents.py`
+  - `MSAgentFrameworkHarness` (stub → real in P5) —
+    `src/assistant/harnesses/sdk/ms_agent_fw.py`
+  - Pi harness — proposed, not yet implemented
+- **Conformance suite:** not yet — current tests are per-harness, not
+  cross-harness. A `tests/conformance/test_harness_adapter.py` covering
+  `name()`, `harness_type()`, `create_agent()`, `invoke()`, and
+  `spawn_sub_agent()` against a mock persona/role/tool fixture is
+  prerequisite to a second non-stub implementation.
+- **Known leaks:**
+  - `spawn_sub_agent()` returns a `str` (`base.py:39-45`), assuming a
+    single text reply. Sub-agent results may legitimately be structured
+    (citations, tool traces, plan deltas). Move to a typed result envelope
+    once a second harness exercises this path.
+  - `create_agent()`'s `tools` and `extensions` arguments are
+    `list[Any]` (`base.py:31-33`) — the protocol doesn't constrain shape.
+    This will tighten once `CapabilityRegistry` is the discovery source.
+  - `spawn_sub_agent()` lives on the harness at all — should move to
+    `AgentRegistry` once that primitive exists.
+- **Open questions:**
+  - Streaming surface: `invoke()` is sync-shaped (`str` return). Should it
+    return `AsyncIterator[Event]` instead? Likely yes; deferred until a
+    consumer needs streaming (the CLI doesn't yet).
+  - Cancellation / interrupt: no method today; LangGraph and Pi both
+    support it natively. Add when needed.
+  - Memory wiring: today each adapter wires its own memory (DeepAgents
+    via `InMemorySaver`, MSAF via prepend). After `MemoryManager` lands,
+    adapters consume from it; the interface should declare a `memory`
+    constructor parameter.
+
+---
+
+### `Extension` protocol
+
+- **Code:** `src/assistant/extensions/base.py:15`
+- **Stability:** **Provisional** (with a known deprecation path)
+- **Providers:**
+  - Empty-tool stubs for `ms_graph`, `teams`, `sharepoint`, `outlook`,
+    `gmail`, `gcal`, `gdrive` (`src/assistant/extensions/`)
+  - Real MS extensions arrive in `ms-graph-extension` phase (P5)
+  - Real Google extensions arrive in `google-extensions` phase
+- **Conformance suite:** not yet — extension health checks are
+  per-extension. A `tests/conformance/test_extension.py` covering
+  `name`, `health_check()`, and the future `register()` is owed.
+- **Known leaks (load-bearing):**
+  - **Dual-surface methods** `as_langchain_tools()` and
+    `as_ms_agent_tools()` (`base.py:19-21`) bake consumer identity into
+    the protocol. Adding a Pi consumer requires either a third method
+    (`as_pi_tools()`) or a refactor. Refactor is the right move: replace
+    with `register(registry: CapabilityRegistry, persona: PersonaConfig)`
+    once `CapabilityRegistry` exists. This is the cleanest example in the
+    repo of a leaked interface.
+- **Open questions:**
+  - What does `register()` accept exactly? OpenAPI specs? Pure JSON
+    Schema + handler references that the registry wraps into OpenAPI?
+    Both? Resolution comes with the `CapabilityRegistry` design.
+  - Should extensions declare their persona-affinity (e.g. "this
+    extension is only for `work`") at the protocol level, or via
+    persona-side config? Lean toward the latter to keep the protocol
+    persona-agnostic.
+
+---
+
+### `CapabilityRegistry` (proposed)
+
+- **Code:** not yet as a unified primitive; substantial precursor
+  exists as `HttpToolRegistry` from archived P3 http-tools-layer
+  (HTTP + OpenAPI discovery, `$ref` resolution, auth handling,
+  registry pattern, `--list-tools` CLI flag). `ToolPolicy` protocol
+  exists from P1.8 capability-protocols.
+- **Stability:** **Experimental** (precursor real and shipping;
+  lifting to a unified primitive with multiple projections is the
+  proposed `capability-registry` phase)
+- **Providers:**
+  - `HttpToolRegistry` — partial implementation, current; four open
+    follow-ups (#16–#19 in archived `http-tools-layer`)
+  - Extensions exposed via `as_langchain_tools()` /
+    `as_ms_agent_tools()` — current dual-surface pattern to be
+    replaced
+  - Self-hosted MCP gateway — planned projection target
+  - CLI projection (`assistant tool …`) — partial today via
+    `--list-tools`
+  - AgentCore Gateway — slot-compatible if the canonical form is
+    OpenAPI-compatible
+- **Conformance suite:** not yet — design first.
+- **Known leaks (design-time):**
+  - OpenAPI 3.x as the canonical form is the right baseline but needs
+    extensions: streaming/progress (`x-aa-streaming`), persona/role
+    scoping (`x-aa-roles`), per-projection auth policy
+    (`x-aa-auth.<projection>`). Define these as a vendor extension
+    namespace before any extension publishes specs.
+  - "Tool" vs "skill" vs "agent" — all three are capabilities at the
+    registry level but they are not the same thing. The registry needs
+    a `kind` field and the discovery API needs to filter by it.
+- **Open questions:**
+  - In-process vs out-of-process: is the registry a Python object the
+    harness imports, or a service the harness queries over HTTP/MCP?
+    Both, with the same canonical form — in-process for fast path,
+    out-of-process for cross-runtime.
+  - Authority for `GuardrailProvider.authorize(persona, role, capability,
+    projection)`: does the registry call out to a separate provider, or
+    is authorization baked into discovery results? Lean toward the
+    former for clean separation.
+  - Hot-add semantics: when an extension publishes a new capability,
+    when is it visible to existing sessions? Next turn, or next session?
+    Per-projection answer (MCP supports notifications; HTTP can poll).
+
+---
+
+### `MemoryManager`
+
+- **Code:** `src/assistant/core/memory.py:20` (real, archived P2
+  memory-architecture); `MemoryPolicy` protocol in
+  `src/assistant/core/capabilities/` (real, archived P1.8
+  capability-protocols)
+- **Stability:** **Experimental** (real implementation exists; interface
+  shape has known load-bearing leaks; conformance suite not yet
+  written)
+- **Providers:**
+  - Postgres + Graphiti via `MemoryManager` (current);
+    `PostgresGraphitiMemoryPolicy` auto-selected when `database_url`
+    configured
+  - Letta self-host, Zep self-host, mem0 self-host — candidates
+  - LangGraph `PostgresStore` — could back the local provider directly
+  - AgentCore Memory — managed slot once work persona lands (P15)
+  - Foundry Memory — managed alternative for Azure-bound work persona
+- **Conformance suite:** not yet — `MemoryPolicy` has tests but no
+  cross-provider conformance harness exists. Required before lifting
+  to Provisional.
+- **Known leaks (load-bearing):**
+  - **Persona parameter on methods.** `get_context(persona, role, …)`,
+    `store_fact(persona, key, value)`, `store_interaction(persona, …)`,
+    and similar methods accept a `persona: str` parameter
+    (`memory.py:30, 65, etc.`). Under git-as-multi-tenancy this is
+    leakage — each instance is already persona-bound at construction
+    via the `session_factory`; the method parameter is a relic of a
+    multi-tenant assumption that doesn't apply (see
+    `primitives-and-providers.md` → "Privacy boundary"). Cleanup
+    folds into the `binding-manifest` phase: drop the parameter, the
+    instance is the persona's manager.
+  - The MSAF "minimal-prepend" pattern (D27) treats memory as a
+    read-only context source. The full interface supports
+    write-through and async ingestion; the minimal-prepend pattern is
+    fine as a read implementation but must not constrain the
+    interface shape.
+- **Semantic conformance points (currently unspecified — gaps):**
+  - What does `get_context()` guarantee about freshness? Are writes
+    from the same turn visible to subsequent `get_context()` calls?
+    Not specified.
+  - What does `store_fact()` guarantee about durability — is the call
+    durable on return, or only after `session.commit()`? Implementation
+    commits, but not documented in the interface.
+  - Cross-thread / cross-process visibility within the same persona
+    (e.g. scheduler writes + REPL reads): not specified.
+- **Open questions:**
+  - Distinction between session memory (this conversation) and
+    long-term memory (across conversations). AgentCore models them
+    as one service; Letta separates them; LangGraph treats
+    checkpointers and stores as distinct. Current code couples them
+    via `MemoryManager`; the binding-manifest phase should consider
+    splitting `SessionStore` out.
+  - Write-through vs async ingestion: Graphiti entity extraction is
+    too slow for the hot path. Architecture: write to a fast log
+    (Postgres `memory` table) synchronously; async pipeline distills
+    into the persona's graph. Currently both happen synchronously;
+    needs async pipeline for scale.
+  - Forgetting: GDPR-shaped delete requests. Required for `personal`;
+    likely required for `work` under employer policy. Define
+    `MemoryManager.forget(query)` with provider-specific semantics.
+
+---
+
+### `IdentityProvider` (proposed)
+
+- **Code:** not yet — `bao-vault` skill exists for OpenBao operations
+  but no agent-facing interface
+- **Stability:** **Pre-interface**
+- **Providers:**
+  - OpenBao / HashiCorp Vault self-host — primary local provider
+  - AgentCore Identity — managed, for `work` if employer is AWS
+  - Azure Managed Identity — managed, for `work` if employer is Azure
+  - AWS IAM / Workload Identity Federation — for non-AgentCore AWS
+- **Conformance suite:** not yet.
+- **Known leaks (design-time):**
+  - Two concerns are conflated in the name "identity": (a) credentials
+    the agent uses to call third-party APIs (OAuth tokens, API keys),
+    (b) the agent's own workload identity for service-to-service auth.
+    AgentCore Identity handles both; OpenBao primarily handles (a) via
+    secret storage. The interface must distinguish these or providers
+    won't slot.
+  - Per-projection auth interacts with this: the `CapabilityRegistry`
+    needs an `IdentityProvider` to resolve credentials when projecting
+    a tool over HTTP that requires OAuth.
+- **Open questions:**
+  - Token refresh: managed providers handle it transparently; OpenBao
+    requires explicit refresh logic. Should the interface paper over
+    this, or expose it as a capability?
+  - Audit trail: managed providers emit audit events; local Vault
+    requires the caller to log. Surface as a capability.
+
+---
+
+### `SessionStore` (proposed)
+
+- **Code:** not yet — LangGraph `InMemorySaver` used directly in
+  `harnesses/sdk/deep_agents.py:60`
+- **Stability:** **Pre-interface**
+- **Providers:**
+  - LangGraph `InMemorySaver`, `SqliteSaver`, `PostgresSaver`
+  - Pi `SessionManager` (JSON-L) — interesting because it survives
+    process restarts trivially
+  - AgentCore session state — managed
+  - OpenAI Threads — managed
+- **Conformance suite:** not yet.
+- **Known leaks (design-time):**
+  - LangGraph's `thread_id` is a session-identity concept that not all
+    providers expose. The interface should use an opaque `SessionId`
+    type and let providers map.
+  - Forking and branching: Pi has it natively; LangGraph supports
+    time-travel; managed providers vary. Surface as a capability, not
+    a required method.
+- **Open questions:**
+  - Lift this primitive now (force the design with one provider) or
+    wait until a second harness needs the same checkpoint behaviour?
+    Lean toward lift-on-second-consumer to avoid premature abstraction.
+  - Relationship to `MemoryManager`: session writes feed memory
+    ingestion. Define the write hook so memory ingestion can subscribe
+    to session writes without each harness re-implementing the bridge.
+
+---
+
+### `Sandbox` (proposed)
+
+- **Code:** not yet — Pi has built-in `bash`; DeepAgents has no sandbox
+- **Stability:** **Pre-interface**
+- **Providers:**
+  - Local Docker — primary local provider for code execution
+  - Playwright self-host — for browser
+  - e2b.dev self-host — alternative code sandbox
+  - AgentCore Code Interpreter, AgentCore Browser — managed
+  - OpenAI Code Interpreter — managed
+- **Conformance suite:** not yet.
+- **Known leaks:**
+  - Code execution and browsing have legitimately different surfaces
+    (file I/O semantics, network policy, output shapes). Splitting into
+    `CodeSandbox` and `BrowserSandbox` is likely correct; deferred until
+    a real cross-provider need exists.
+- **Open questions:**
+  - Resource limits as a capability: providers vary widely. Worth
+    surfacing as part of the binding configuration so persona-side
+    policy can constrain.
+
+---
+
+### `AgentRegistry` (proposed)
+
+- **Code:** not yet — current spawn lives in `HarnessAdapter` as
+  `spawn_sub_agent` (`harnesses/base.py:39`)
+- **Stability:** **Pre-interface**
+- **Providers:**
+  - In-process Python registry — fast path for same-runtime spawning
+  - A2A protocol — open standard for cross-process / cross-runtime
+  - AgentCore Runtime invocations — managed cross-runtime path
+- **Conformance suite:** not yet.
+- **Known leaks (design-time):**
+  - The current `spawn_sub_agent` constructs a same-type child harness
+    (`DeepAgentsHarness(self.persona, role)` in `deep_agents.py:92`).
+    This prevents cross-harness delegation (e.g., `personal` running
+    DeepAgents delegating an MS-Graph subtask to MSAF). The registry
+    must support cross-harness spawning explicitly.
+- **Open questions:**
+  - Routing policy: when a role asks to spawn, who decides which harness
+    serves the child? Static (role declares preferred harness),
+    dynamic (registry picks based on capability requirements), or
+    hybrid? Hybrid is likely correct — role declares constraints,
+    registry resolves.
+  - Concurrency model: in-process spawns are tasks; A2A spawns are
+    remote calls. The handle type returned must abstract over both.
+
+---
+
+### Observability (OpenTelemetry gen-ai)
+
+- **Code:** `src/assistant/telemetry/` (Langfuse-backed); see also
+  `docs/observability.md`
+- **Stability:** **Provisional** (closest to Stable of any interface
+  here — well-shaped, opt-in, real provider)
+- **Providers:**
+  - Langfuse self-hosted (current, default for `LANGFUSE_ENABLED=true`)
+  - Noop provider (current, default)
+  - Phoenix, Jaeger, Honeycomb — slot-compatible via OTel
+  - AgentCore Observability, Datadog — slot-compatible via OTel
+- **Conformance suite:** test coverage exists for the Langfuse provider
+  (`tests/telemetry/`); cross-provider conformance is implicit via
+  OTel itself. Adding a `tests/conformance/test_tracer.py` is a small
+  next step.
+- **Known leaks:** Graphiti queries are intentionally traced at the
+  `MemoryManager` boundary, not at the Graphiti client layer, to avoid
+  double-counting (`docs/observability.md`). This is correct, but it
+  means the OTel attribute conventions for memory operations are
+  repo-specific until the OTel gen-ai spec covers memory operations
+  formally.
+- **Open questions:**
+  - Span attribute conventions for persona/role: not standardized.
+    The repo uses `assistant.persona` and `assistant.role` (see
+    `set_assistant_ctx` in `cli.py:223`). Either align with an emerging
+    convention or document the choice as a repo-specific dialect.
+
+---
+
+### `SkillResolver` (deferred)
+
+- **Code:** not yet — `.agents/skills/` consumed directly via filesystem
+  walker; `agentic-coding-tools/skills/install.sh` is the upstream sync
+- **Stability:** **Pre-interface**
+- **Providers:**
+  - Filesystem walker — current behaviour
+  - Pi's skill discovery — natively reads the same directories; no
+    adapter needed
+- **Conformance suite:** not yet — interface not yet defined.
+- **Why deferred:** the static-file approach works today. The
+  interface lifts when (a) skills need to be loaded dynamically per
+  turn based on a query, (b) skill matching needs to be policy-gated
+  per role, or (c) a second discovery source materializes (e.g.,
+  fetching skills from a registry).
+- **Open questions:** none yet — design lives in the future.
+
+## How entries change state
+
+A change to any entry follows the same pattern:
+
+1. A PR proposes the change (new entry, stability bump, leak added,
+   conformance test landed).
+2. The PR also touches `primitives-and-providers.md` if the row in
+   that document needs updating (e.g., a new provider entered the
+   matrix).
+3. A leak being **discovered** does not by itself demote stability;
+   a leak being **load-bearing** (consumers depending on it) does.
+4. Stability promotions require the conformance suite. A primitive
+   cannot graduate Experimental → Provisional without a conformance
+   harness, even if a second provider exists.
+5. Managed-provider claims of conformance require a periodic
+   verification job (see "Conformance against managed providers"
+   above). Mock-only conformance caps a provider at Provisional.
+
+## Ledger drift mitigation
+
+The ledger's value collapses to zero if entries lag the code. Two
+mitigations, in increasing strength:
+
+1. **Reviewer obligation (current):** any PR that modifies
+   `src/assistant/harnesses/`, `src/assistant/extensions/`,
+   `src/assistant/core/memory*` (when added),
+   `src/assistant/telemetry/`, or related interface files must touch
+   the corresponding ledger entry. Reviewers reject PRs that don't.
+2. **CI gate (implemented):** `scripts/check-architecture-ledger-drift.py`
+   fails when interface-bearing files change without touching
+   `docs/architecture/interface-stability.md` or
+   `docs/architecture/primitives-and-providers.md`.
+
+The ledger is meant to be edited frequently. A stale entry is worse
+than a missing one — it silently lies to consumers about what they
+can depend on.
+
+## Open meta-questions
+
+Questions about the ledger itself rather than any specific entry:
+
+- Should this document live in `docs/architecture/` or in
+  `openspec/specs/`? OpenSpec handles requirement-shaped artifacts
+  well, but interface stability is more of a continuously-maintained
+  ledger than a delta. Current call: docs/architecture/, with OpenSpec
+  changes referencing entries by name.
+- Frequency of review: every PR that touches a primitive should
+  consider whether the ledger entry needs updating. A quarterly
+  consolidation pass keeps the ledger honest.
+- Cross-link to the gotchas document: gotchas often surface from
+  ledger entries (e.g., G6 is a privacy-boundary gotcha that connects
+  to `MemoryManager` design). Reciprocal links from each gotcha to
+  the relevant primitive are owed.

--- a/docs/architecture/primitives-and-providers.md
+++ b/docs/architecture/primitives-and-providers.md
@@ -87,12 +87,12 @@ still under design. Stability classification per interface lives in
 
 | Primitive | Interface (repo-owned contract) | Local / OSS providers | Managed providers |
 |---|---|---|---|
-| **Models** (LLMs) | `ChatModel` — init, invoke, stream, tool-calling, vision, thinking budget | Ollama, vLLM, llama.cpp; LiteLLM or Pi-ai as cross-provider façades | Anthropic, OpenAI, Google, Bedrock, Vertex, Azure OpenAI, xAI, Groq, Fireworks, Together |
-| **Harness / Framework** | `HarnessAdapter` (`src/assistant/harnesses/base.py:12`); SDK and Host tiers | DeepAgents/LangGraph (implemented), MSAF (stub → P5), Pi (proposed), Strands, ADK, OpenAI Agents SDK, CrewAI, AutoGen | AgentCore Runtime, Bedrock Agents, OpenAI Assistants, Azure AI Foundry Agents, Vertex Agent Builder, Anthropic managed agents (when shipped) |
+| **Models** (LLMs) | `ModelProvider` / `ModelRef` (`core/capabilities/models.py`, realized P19) — capability-tagged registry → harness-neutral `ModelRef` → per-consumer bindings; budget via `GuardrailProvider`, keys via `CredentialProvider` | Ollama, vLLM, llama.cpp; OpenRouter (OpenAI-compatible `base_url`) as cross-provider façade | Anthropic, OpenAI, Google (`google_genai`/`google_vertexai`), Bedrock (`bedrock_converse`), Azure OpenAI, xAI, Groq, Fireworks, Together |
+| **Harness / Framework** | `HarnessAdapter` (`src/assistant/harnesses/base.py:20`); SDK and Host tiers | DeepAgents/LangGraph (implemented), MSAF (**real**, P5), ClaudeCode (Host tier, P1.8), Pi (proposed), Strands, ADK, OpenAI Agents SDK, CrewAI, AutoGen | AgentCore Runtime, Bedrock Agents, OpenAI Assistants, Azure AI Foundry Agents, Vertex Agent Builder, Anthropic managed agents (when shipped) |
 | **Capability Registry** | `CapabilityRegistry` (proposed) — publish, discover, project; OpenAPI canonical form with streaming and scoping extensions | `HttpToolRegistry` (current, partial); self-hosted MCP gateway projecting OpenAPI; CLI projection | AgentCore Gateway, OpenAI Tools, Azure Foundry Connectors |
-| **Memory** | `MemoryManager` (proposed) — read by query, ingest event, semantic search, forget, per-persona isolation | Postgres + Graphiti (planned), Letta, Zep self-host, mem0 self-host, Cognee, LangGraph `PostgresStore` | AgentCore Memory, OpenAI Threads/Memory, Foundry Memory, Anthropic memory primitives (when shipped) |
+| **Memory** | `MemoryManager` (`core/memory.py:21`, real) — read by query, ingest event, semantic search, per-persona isolation (bound at construction, mismatch-validated) | Postgres + Graphiti (implemented), Letta, Zep self-host, mem0 self-host, Cognee, LangGraph `PostgresStore` | AgentCore Memory, OpenAI Threads/Memory, Foundry Memory, Anthropic memory primitives (when shipped) |
 | **Identity** | `IdentityProvider` (proposed) — credential vault for agent-to-tool/agent-to-service auth, workload identity | OpenBao / HashiCorp Vault (`bao-vault` skill); local OAuth flows | AgentCore Identity, Azure Managed Identity, AWS IAM, Workload Identity Federation, OpenAI service accounts |
-| **Sessions / Checkpointing** | `SessionStore` (proposed) — persist conversation state, fork, branch, resume | LangGraph `InMemorySaver` (current), `SqliteSaver`, `PostgresSaver`, Pi `SessionManager` (JSON-L) | AgentCore session state, OpenAI Threads, Foundry runs |
+| **Sessions / Checkpointing** | `SessionRegistry` (`harnesses/sessions.py:67`, real P30) — create/lookup/resolve/expire by `thread_id`; LangGraph checkpointer binding | LangGraph `InMemorySaver` (default tier) + **Postgres durable tier** (P30), `SqliteSaver`, `PostgresSaver`, Pi `SessionManager` (JSON-L) | AgentCore session state, OpenAI Threads, Foundry runs |
 | **Observability** | OpenTelemetry gen-ai semantic conventions; thin `Tracer` wrapper at boundaries | Langfuse self-hosted (current, see [`observability.md`](../observability.md)), Phoenix, Jaeger | AgentCore Observability, Datadog, Honeycomb, LangSmith |
 | **Sandboxes** (code, browser) | `Sandbox` (proposed) — bounded execution surface, capability-gated | Docker + Playwright, e2b.dev self-host, Pi built-in `bash` | AgentCore Code Interpreter, AgentCore Browser, OpenAI Code Interpreter, e2b.dev managed |
 | **Agent Registry** | `AgentRegistry.spawn(...)` (proposed) — local in-process fast path; A2A for cross-process / cross-runtime | In-process Python registry; A2A bridge for cross-runtime | AgentCore Runtime invocations, OpenAI Assistants handoffs, Foundry agent orchestration |
@@ -156,17 +156,34 @@ Honest accounting of the matrix as of writing:
   `CapabilityRegistry` land (sub-agent spawning and tool wiring move
   out of the adapter). DeepAgents harness implemented; MS Agent
   Framework harness implemented in P5 (archived).
-- `Extension` protocol (`extensions/base.py:15`) — currently leaky:
-  the `as_langchain_tools()` / `as_ms_agent_tools()` dual-surface
-  bakes consumer identity into the protocol. Slated for replacement
-  by a `register(registry, persona)` shape once `CapabilityRegistry`
-  exists. Real MS extensions ship (P5 archived); Google extensions
-  pending (P14).
-- `MemoryManager` (`core/memory.py:20`) — real, archived P2
+- `Extension` protocol (`extensions/base.py:66`) — the leaky
+  `as_langchain_tools()` / `as_ms_agent_tools()` dual-surface was
+  **removed** in P17 `mcp-server-exposure`. Extensions now emit the
+  harness-neutral `ToolSpec` (`core/toolspec.py`) via
+  `tool_specs() -> list[ToolSpec]`, rendered per-harness by
+  `harnesses/tool_adapters.py`. Real MS extensions ship (P5 archived);
+  Google extensions pending (P14/google-extensions).
+- `ToolSpec` (`core/toolspec.py`, P17) — the single internal,
+  harness-neutral tool representation (MCP-shaped: name, description,
+  JSON-Schema `input_schema`, async handler, `source` provenance).
+  `ToolPolicy.authorized_tools()` is the sole aggregator; every tool
+  source (extensions, OpenAPI-derived HTTP tools) compiles into it.
+- `MemoryManager` (`core/memory.py:21`) — real, archived P2
   memory-architecture. Postgres + Graphiti dual-backed; auto-selects
   `PostgresGraphitiMemoryPolicy` when `database_url` configured.
-  Known leak: methods take `persona: str` parameter that should not
-  exist under git-as-multi-tenancy (see "Privacy boundary" above).
+  The former `persona: str` leak is now `persona: str | None`: the
+  manager binds to a persona at construction and **raises on a
+  mismatched explicit persona** (see "A known interface leak" below).
+- `ModelProvider` / `ModelRef` (`core/capabilities/models.py`,
+  `model_bindings.py`) — real, archived P19 model-provider-routing.
+  Capability-tagged per-persona model registry resolving to a
+  harness-neutral `ModelRef` with thin per-consumer bindings; both SDK
+  harnesses and direct calls consume it instead of raw model-id strings.
+- `SessionRegistry` + durable checkpointer
+  (`harnesses/sessions.py`, `harnesses/sdk/checkpointer.py`) — real,
+  archived P30 durable-sessions. LangGraph checkpointer with a Postgres
+  durable tier (`sessions: {durable: true}`); session
+  create/lookup/resolve/expire by `thread_id`.
 - `HttpToolRegistry` + OpenAPI discovery from persona `tool_sources`
   — real, archived P3 http-tools-layer. Substantial precursor to the
   unified `CapabilityRegistry` proposed below. Four open follow-ups
@@ -186,10 +203,6 @@ Honest accounting of the matrix as of writing:
   the proposed `capability-registry` phase.
 - `IdentityProvider` — OpenBao integration exists at the script
   level (`bao-vault` skill) but no agent-facing interface yet.
-- `SessionStore` — LangGraph `InMemorySaver` used directly by the
-  DeepAgents adapter (per archived fix-harness-conversation-memory).
-  Lift to a primitive once a second harness needs the same
-  capability.
 - `Sandbox` — currently per-harness. Lift when sandbox use becomes
   cross-harness.
 - `AgentRegistry` — implicit in `spawn_sub_agent` today; should be
@@ -348,21 +361,29 @@ AgentCore Memory holding `personal` long-term memory violates
 `personal`'s explicit data-sovereignty constraint; the same provider is
 appropriate for `work` if employer policy permits.
 
-### A known interface leak
+### A known interface leak — now largely closed
 
-`MemoryManager` at `src/assistant/core/memory.py:20` currently takes
-`persona: str` as a parameter on methods like `get_context()`,
-`store_fact()`, and similar (e.g. `memory.py:30, 65`). Under
-git-as-multi-tenancy this parameter is **leakage from a defunct
-multi-tenant assumption**: each `MemoryManager` instance is constructed
-inside a process that is already bound to exactly one persona (the
-`session_factory` is per-persona), so the method parameter cannot
-validly differ from the instance's persona. The caller shouldn't have
-to supply information the instance already knows.
+`MemoryManager` at `src/assistant/core/memory.py:21` historically took
+`persona: str` as a required parameter on methods like `get_context()`,
+`store_fact()`, and similar. Under git-as-multi-tenancy that was
+**leakage from a defunct multi-tenant assumption**: each instance is
+constructed inside a process already bound to exactly one persona (the
+`session_factory` is per-persona), so the parameter could not validly
+differ from the instance's persona.
 
-The cleanup is mechanical — drop the parameter, the instance is the
-persona's manager — and folds naturally into the `binding-manifest`
-phase. Tracked as a load-bearing leak in
+This has since been addressed rather than merely tracked. The parameter
+is now `persona: str | None`, the manager **binds to its persona at
+construction** (`persona_name`), and `_resolve_persona`
+(`memory.py:32`) **raises `ValueError` if a caller passes an explicit
+persona that disagrees with the bound one** — a bound manager refuses to
+touch another persona's data instead of silently honouring either side.
+Bound callers pass `None` and the instance supplies the persona it
+already knows. Unbound managers (the CLI/host construction sites) still
+require an explicit persona, so those call sites are unchanged.
+
+Remaining work is cosmetic, not correctness: the parameter is optional
+rather than gone. Fully dropping it folds into the `binding-manifest`
+phase. Tracked in
 [`interface-stability.md`](./interface-stability.md) →
 `MemoryManager`.
 

--- a/docs/architecture/primitives-and-providers.md
+++ b/docs/architecture/primitives-and-providers.md
@@ -1,0 +1,399 @@
+# Primitives and Providers
+
+This document is the architectural statement of `agentic-assistant`. It names
+the agent-platform **primitives** the repo abstracts over, the **interfaces**
+those primitives present, and the **providers** (local reference
+implementations, third-party open-source projects, and managed services) that
+can be plugged in behind each interface on a per-persona basis.
+
+The single sentence: **the repo's value is not any one implementation; it is
+the persona-scoped composition of selected providers behind stable interfaces,
+with a privacy boundary between personas.**
+
+## Architectural framing
+
+This is the Service Provider Interface (SPI) pattern applied to agent
+primitives. The same pattern shows up across software history:
+
+- **JDBC / Python DB-API** — interface over relational databases; drivers per
+  vendor; conformance test kits ensure swap-ability.
+- **Kubernetes CRI/CNI/CSI** — interfaces over container runtime, networking,
+  and storage; operators pick providers per cluster.
+- **SQLAlchemy dialects** — one ORM surface, N database backends.
+- **Terraform providers** — one config language, N cloud and SaaS targets.
+- **OpenTelemetry exporters** — one instrumentation surface, N backends.
+
+The pattern earns its keep when three disciplines are honoured: interfaces
+stay narrow (every method is a coupling point), conformance tests verify
+that any implementation satisfies the contract, and feature matrices
+acknowledge legitimate per-provider divergence without polluting the core
+interface.
+
+A **persona** in this repo is a configuration bundle — which model, which
+harness, which memory backend, which identity store, which tool catalog, which
+observability backend — bound together with a private config repo (mounted as
+a submodule under `personas/<name>/`) and its own database. A **role** is a
+behavioural overlay (prompt, delegation rules, preferred tools) that runs
+on top of whatever provider mix the persona selects.
+
+### What's actually novel
+
+Narrowed honestly: the load-bearing novelty in this repo is not the
+persona-and-role concept itself (multi-tenant agent platforms achieve
+analogous boundaries; role-as-system-prompt-fragment is well-explored).
+The unprecedented combination is:
+
+- **Git itself as the multi-tenancy mechanism.** Instead of building
+  `tenant_id` into every table, API call, cache key, and policy check,
+  the repo offloads multi-tenancy entirely to git access control,
+  filesystem isolation, and per-persona process boundaries. The
+  primitives are **single-tenant by design** because two personas
+  never share a process; cross-persona work is cross-process (A2A).
+  This mirrors how Unix achieves per-user isolation via the kernel
+  rather than per-application code, how Kubernetes namespaces are
+  enforced by the control plane rather than each operator, and how
+  email isolates users via per-mailbox storage rather than a
+  user-id column on a shared `messages` table. The choice collapses
+  an enormous category of complexity that managed multi-tenant
+  platforms (AgentCore, Foundry, OpenAI Assistants) have to carry.
+- **Public code, private config via per-persona git submodules** is
+  the mechanism that implements the architectural choice above. The
+  public repo can ship open-source while every persona's credentials,
+  role overrides, DB schema, and skill set live in independent private
+  submodules under `personas/<name>/`. No managed agent platform
+  offers this split because they assume cloud-hosted tenant isolation;
+  no open-source framework offers it because they assume a single
+  user.
+- **A two-layer privacy guard** (`tests/_privacy_guard_plugin.py`
+  plus `tests/conftest.py`) is the dev-time discipline that catches
+  attempts to bake private content into public artifacts. It enforces
+  the public/private split at test collection time (substring scan
+  for private-persona identifiers) and at runtime (FS I/O patching
+  against private paths). This is the artifact that turns the
+  submodule split from convention into contract.
+
+Persona-as-execution-boundary, role-as-overlay, and SPI-shaped provider
+selection are the *delivery vehicle* for that novelty. They are not the
+novelty themselves; they are well-trodden patterns adapted to carry
+the git-as-multi-tenancy choice cleanly.
+
+## The primitive table
+
+Each row is a primitive. Each row defines an **interface** (the abstract
+contract the repo owns), names current and prospective **providers** for it,
+and notes whether the interface is currently realized in code, planned, or
+still under design. Stability classification per interface lives in
+[`interface-stability.md`](./interface-stability.md).
+
+| Primitive | Interface (repo-owned contract) | Local / OSS providers | Managed providers |
+|---|---|---|---|
+| **Models** (LLMs) | `ChatModel` — init, invoke, stream, tool-calling, vision, thinking budget | Ollama, vLLM, llama.cpp; LiteLLM or Pi-ai as cross-provider façades | Anthropic, OpenAI, Google, Bedrock, Vertex, Azure OpenAI, xAI, Groq, Fireworks, Together |
+| **Harness / Framework** | `HarnessAdapter` (`src/assistant/harnesses/base.py:12`); SDK and Host tiers | DeepAgents/LangGraph (implemented), MSAF (stub → P5), Pi (proposed), Strands, ADK, OpenAI Agents SDK, CrewAI, AutoGen | AgentCore Runtime, Bedrock Agents, OpenAI Assistants, Azure AI Foundry Agents, Vertex Agent Builder, Anthropic managed agents (when shipped) |
+| **Capability Registry** | `CapabilityRegistry` (proposed) — publish, discover, project; OpenAPI canonical form with streaming and scoping extensions | `HttpToolRegistry` (current, partial); self-hosted MCP gateway projecting OpenAPI; CLI projection | AgentCore Gateway, OpenAI Tools, Azure Foundry Connectors |
+| **Memory** | `MemoryManager` (proposed) — read by query, ingest event, semantic search, forget, per-persona isolation | Postgres + Graphiti (planned), Letta, Zep self-host, mem0 self-host, Cognee, LangGraph `PostgresStore` | AgentCore Memory, OpenAI Threads/Memory, Foundry Memory, Anthropic memory primitives (when shipped) |
+| **Identity** | `IdentityProvider` (proposed) — credential vault for agent-to-tool/agent-to-service auth, workload identity | OpenBao / HashiCorp Vault (`bao-vault` skill); local OAuth flows | AgentCore Identity, Azure Managed Identity, AWS IAM, Workload Identity Federation, OpenAI service accounts |
+| **Sessions / Checkpointing** | `SessionStore` (proposed) — persist conversation state, fork, branch, resume | LangGraph `InMemorySaver` (current), `SqliteSaver`, `PostgresSaver`, Pi `SessionManager` (JSON-L) | AgentCore session state, OpenAI Threads, Foundry runs |
+| **Observability** | OpenTelemetry gen-ai semantic conventions; thin `Tracer` wrapper at boundaries | Langfuse self-hosted (current, see [`observability.md`](../observability.md)), Phoenix, Jaeger | AgentCore Observability, Datadog, Honeycomb, LangSmith |
+| **Sandboxes** (code, browser) | `Sandbox` (proposed) — bounded execution surface, capability-gated | Docker + Playwright, e2b.dev self-host, Pi built-in `bash` | AgentCore Code Interpreter, AgentCore Browser, OpenAI Code Interpreter, e2b.dev managed |
+| **Agent Registry** | `AgentRegistry.spawn(...)` (proposed) — local in-process fast path; A2A for cross-process / cross-runtime | In-process Python registry; A2A bridge for cross-runtime | AgentCore Runtime invocations, OpenAI Assistants handoffs, Foundry agent orchestration |
+| **Skill discovery** | `SkillResolver` (proposed) — given query, return matching skills; consume `~/.agents/skills/` and `.agents/skills/` layouts | In-repo skill walker (synced from `agentic-coding-tools/skills/`); Pi's native skill discovery | (No managed equivalent today) |
+
+The repo holds the interface column. Providers in the local/OSS column are
+either implemented, planned, or candidates the repo is positioned to adopt
+without core changes. Providers in the managed column are slot-compatible
+once interface adapters exist; they are not preconditions for the local
+column to be useful.
+
+## Example persona compositions
+
+The provider selection is per-persona, not global. Two illustrative
+compositions:
+
+### `personal` persona — local-first, sovereign
+
+| Primitive | Provider |
+|---|---|
+| Models | Claude via Anthropic API; Ollama for offline fallback |
+| Harness | DeepAgents (LangGraph) for general reasoning; Pi for code/file/shell tasks (post-integration) |
+| Capability Registry | Self-hosted MCP gateway over the repo's HTTP+OpenAPI tool registry |
+| Memory | Local Postgres + Graphiti, scoped to `personas/personal/` DB |
+| Identity | OpenBao vault holding personal API keys |
+| Sessions | LangGraph `PostgresSaver` against persona-local Postgres |
+| Observability | Self-hosted Langfuse (per `docs/observability.md`) |
+| Sandboxes | Local Docker for code execution; Playwright for browser |
+| Agent Registry | In-process Python registry |
+| Skill discovery | Repo `.agents/skills/` synced from `agentic-coding-tools` |
+
+### `work` persona — employer-cloud, leverage managed services
+
+| Primitive | Provider |
+|---|---|
+| Models | Whichever frontier models the employer licenses (Claude / GPT / Gemini via Bedrock / Azure / Vertex) |
+| Harness | MSAF for M365-shaped work; AgentCore Runtime for serverless agents |
+| Capability Registry | AgentCore Gateway federating internal APIs and employer SaaS |
+| Memory | AgentCore Memory (or Foundry Memory on Azure shops) |
+| Identity | AgentCore Identity bridged to employer SSO / Azure Managed Identity |
+| Sessions | AgentCore session state |
+| Observability | AgentCore Observability → employer APM (Datadog / Splunk / etc.) |
+| Sandboxes | AgentCore Code Interpreter, AgentCore Browser |
+| Agent Registry | AgentCore Runtime + A2A for cross-process spawning |
+| Skill discovery | Same as `personal` (skills are persona-portable) |
+
+The role catalog (`roles/researcher`, `roles/triage`, `roles/coder`, etc.),
+the persona × role prompt composition (`src/assistant/core/composition.py`),
+the privacy guard (`tests/_privacy_guard_plugin.py`), the OpenSpec workflow,
+and the skill discovery layer are **identical across both personas**. Only
+the provider bindings differ.
+
+## What's filled today vs. aspirational
+
+Honest accounting of the matrix as of writing:
+
+**Interfaces realized in code (real implementations shipping):**
+
+- `HarnessAdapter` and its two tiers (`harnesses/base.py:12,24,48`) —
+  narrow, but a planned shrink is expected once `AgentRegistry` and
+  `CapabilityRegistry` land (sub-agent spawning and tool wiring move
+  out of the adapter). DeepAgents harness implemented; MS Agent
+  Framework harness implemented in P5 (archived).
+- `Extension` protocol (`extensions/base.py:15`) — currently leaky:
+  the `as_langchain_tools()` / `as_ms_agent_tools()` dual-surface
+  bakes consumer identity into the protocol. Slated for replacement
+  by a `register(registry, persona)` shape once `CapabilityRegistry`
+  exists. Real MS extensions ship (P5 archived); Google extensions
+  pending (P14).
+- `MemoryManager` (`core/memory.py:20`) — real, archived P2
+  memory-architecture. Postgres + Graphiti dual-backed; auto-selects
+  `PostgresGraphitiMemoryPolicy` when `database_url` configured.
+  Known leak: methods take `persona: str` parameter that should not
+  exist under git-as-multi-tenancy (see "Privacy boundary" above).
+- `HttpToolRegistry` + OpenAPI discovery from persona `tool_sources`
+  — real, archived P3 http-tools-layer. Substantial precursor to the
+  unified `CapabilityRegistry` proposed below. Four open follow-ups
+  (#16–#19) address known gaps.
+- Observability — real, archived P4 observability. Langfuse-backed
+  with OTel-shaped spans on `HarnessAdapter.invoke()`,
+  `DelegationSpawner.delegate()`, and memory operations.
+- Capability protocols (`GuardrailProvider`, `SandboxProvider`,
+  `MemoryPolicy`, `ToolPolicy`, `ContextProvider`) and
+  `CapabilityResolver` — real, archived P1.8 capability-protocols.
+
+**Interfaces planned but not yet defined as unified primitives:**
+
+- `CapabilityRegistry` — unifying primitive over `HttpToolRegistry`
+  plus extension tools and MCP servers, with multiple consumer
+  projections (LangChain, MSAF, Pi, MCP, CLI). Design pending in
+  the proposed `capability-registry` phase.
+- `IdentityProvider` — OpenBao integration exists at the script
+  level (`bao-vault` skill) but no agent-facing interface yet.
+- `SessionStore` — LangGraph `InMemorySaver` used directly by the
+  DeepAgents adapter (per archived fix-harness-conversation-memory).
+  Lift to a primitive once a second harness needs the same
+  capability.
+- `Sandbox` — currently per-harness. Lift when sandbox use becomes
+  cross-harness.
+- `AgentRegistry` — implicit in `spawn_sub_agent` today; should be
+  lifted out of `HarnessAdapter`.
+- `BindingManifest` — declarative deployment artifact unifying
+  `persona.yaml` + harness config + capability bindings + sink
+  configuration. Proposed as a foundational phase.
+
+**Interfaces deferred:**
+
+- `SkillResolver` — `.agents/skills/` layout is stable and
+  consumed directly today; formal interface waits until dynamic
+  skill loading per turn matters.
+
+## Cross-cutting concerns the matrix hides
+
+The primitive table draws clean per-row separations. Real systems have
+wiring between rows, and these cross-cuts are where SPI patterns
+classically leak. Naming the cross-cuts explicitly here so they are
+not rediscovered per integration:
+
+- **Event-schema agreement** between `HarnessAdapter` (emits) and
+  `MemoryManager` (consumes). The two interfaces share a vocabulary —
+  user message, assistant message, tool call, tool result, plan delta —
+  that neither interface "owns." A normalized event envelope must live
+  at the architecture level, not inside any one provider.
+- **Span propagation** across `HarnessAdapter` → `CapabilityRegistry` →
+  `IdentityProvider` → external API. OTel context propagation
+  conventions must be shared and enforced; otherwise traces fracture
+  at the first cross-primitive boundary.
+- **Identity reference vocabulary.** When `CapabilityRegistry` projects
+  an HTTP tool that requires OAuth, the projection layer must call
+  `IdentityProvider` with a stable identifier for "which credential
+  for this persona/role/projection." That identifier is shared
+  vocabulary; both primitives must agree on its shape.
+- **Session ↔ memory write hook.** `SessionStore` writes feed
+  `MemoryManager` ingestion. Each harness must not re-implement the
+  bridge; define the hook once.
+- **Compatibility groups.** Some role requirements span multiple
+  primitives (e.g. `interrupt_resume` needs harness support + session
+  checkpoint support + memory replay safety). The capability matrix
+  is per-interface; the binding validator must express constraints
+  *across* interfaces or it cannot reject incompatible provider mixes
+  at startup. Compatibility groups are formalized as artifacts within
+  the proposed `binding-manifest` phase (the binding manifest is the
+  declarative artifact the validator runs against); until that lands,
+  they are documented here as a convention rather than enforced.
+
+These cross-cuts are not new primitives. They are conventions that
+several primitives must agree on. They live in this document and the
+stability ledger; they do not get their own interface.
+
+## Role portability — with caveats
+
+The doc's strongest claim — that role definitions are persona-portable —
+holds at the prompt and tool catalog layers but **not unconditionally
+at the execution layer**. The same role YAML produces:
+
+- **Identical prompts** on any binding (composition is provider-agnostic).
+- **Identical tool catalogs** when the bound capability registry has the
+  required capabilities (matrix check at startup).
+- **Divergent execution semantics** for advanced features. A role with
+  `delegation.allowed_sub_roles` spawns via graph nodes on LangGraph,
+  via handoffs on MSAF, via extension-built routing on Pi. The *outcome*
+  is similar in shape; the *guarantees* differ (graph spawn can run in
+  parallel; handoff is sequential by default).
+
+Portability discipline: roles declare their required capabilities
+explicitly; the binding validator rejects persona configurations whose
+provider mix cannot supply them; provider-specific behaviour is opt-in
+via capability declarations, never silent.
+
+## Binding-shaped vs migration-shaped primitives
+
+Not every provider swap is a config change. Distinguishing:
+
+- **Swap-shaped** (binding is config; the change is hot or near-hot):
+  Models (no state), Observability (sinks accept arbitrary streams),
+  Sandboxes (per-invocation, stateless from the architecture's view),
+  Capability Registry (provider catalogs can be merged or swapped),
+  Skill discovery (filesystem is filesystem).
+- **Migration-shaped** (binding implies a deployment event; data or
+  state must move): Memory (long-term storage of facts, entities,
+  timelines), Sessions (resumable conversation state), Identity
+  (tokens and credentials must be re-issued in the new vault).
+- **Borderline** (mostly swap, with state in some implementations):
+  Harness / Framework — runtime is stateless per-session, but bound
+  sessions in flight don't survive a swap mid-session.
+
+Treat migration-shaped primitives accordingly in operational planning:
+they need a migration runbook per provider pair, not a config diff.
+
+This pattern only delivers on its promise if three disciplines are followed:
+
+1. **Conformance test suites per primitive.** Every interface has a test
+   suite (`tests/conformance/test_<primitive>.py`) that any provider
+   implementation must pass. JDBC has a TCK; Python's DB-API has a smaller
+   one; this repo needs its own. Without conformance tests, the interface
+   becomes documentation rather than a contract. The existing privacy guard
+   (`tests/_privacy_guard_plugin.py`) is a precedent for cross-implementation
+   conformance enforcement.
+
+2. **Capability matrices, not feature parity.** Providers will diverge on
+   advanced features (semantic search support, interrupt/resume, streaming
+   shape, multi-modal input). Don't force the interface to the lowest
+   common denominator. Each provider advertises capabilities
+   (`MemoryManager.supports("semantic_search")`,
+   `HarnessAdapter.supports("interrupt_resume")`); roles declare
+   requirements; the persona's binding is rejected at startup if a required
+   capability isn't supplied by its chosen providers.
+
+3. **Narrow interfaces.** Each method on an SPI is a permanent coupling
+   point. Before adding a method, ask whether it could be a capability on
+   an existing method, a method on a different primitive, or pushed into a
+   provider as a non-portable extension. The `Extension` protocol's
+   dual-surface methods are an example of what *not* to do: they encoded
+   consumer identity into the protocol and now have to be unwound.
+
+## Privacy boundary
+
+The persona-as-sovereign-execution-boundary is enforced by **deployment
+topology**, not by defensive code in the primitive interfaces. Each
+persona is a separate deployment with its own DB, its own credentials,
+its own process. Two personas never share an address space, a connection
+string, or a credential vault. Cross-persona reads are not "prevented by
+the interface" — they are *physically impossible* because the topology
+forbids shared infrastructure. The interfaces are single-persona by
+design because, by topology, they will only ever be constructed inside
+a process bound to exactly one persona.
+
+This shifts what each layer of the privacy guard does:
+
+- **Topology layer (load-bearing):** each persona is its own
+  deployment — per-persona DB, per-persona vault, per-persona
+  process. Run two personas, get two processes (same machine,
+  separate hosts, separate clouds — all equivalent from the
+  architecture's perspective). The primitives observe one persona
+  at construction and never have a reason to know about others.
+- **Code layer:** persona-specific config lives in private git
+  submodules under `personas/<name>/`; the public repo never
+  imports from them, only from fixture copies under
+  `tests/fixtures/personas/`. This is the dev-time discipline that
+  prevents private content from being baked into public artifacts.
+- **Test layer:** the two-layer privacy guard
+  (`tests/conftest.py` + `tests/_privacy_guard_plugin.py`) catches
+  dev-time leakage at test collection (substring scan for
+  private-persona identifiers) and at runtime (FS I/O patching).
+  Its job is **narrow** — catch developer mistakes that would bake
+  private content into public artifacts. It is not preventing
+  runtime cross-tenant access, because the topology has already made
+  that impossible.
+
+A managed provider that cannot honour the topology constraint for a
+given persona must not be eligible for that persona's binding.
+AgentCore Memory holding `personal` long-term memory violates
+`personal`'s explicit data-sovereignty constraint; the same provider is
+appropriate for `work` if employer policy permits.
+
+### A known interface leak
+
+`MemoryManager` at `src/assistant/core/memory.py:20` currently takes
+`persona: str` as a parameter on methods like `get_context()`,
+`store_fact()`, and similar (e.g. `memory.py:30, 65`). Under
+git-as-multi-tenancy this parameter is **leakage from a defunct
+multi-tenant assumption**: each `MemoryManager` instance is constructed
+inside a process that is already bound to exactly one persona (the
+`session_factory` is per-persona), so the method parameter cannot
+validly differ from the instance's persona. The caller shouldn't have
+to supply information the instance already knows.
+
+The cleanup is mechanical — drop the parameter, the instance is the
+persona's manager — and folds naturally into the `binding-manifest`
+phase. Tracked as a load-bearing leak in
+[`interface-stability.md`](./interface-stability.md) →
+`MemoryManager`.
+
+## Non-goals
+
+Calling out things this architecture deliberately does **not** try to do:
+
+- **Lowest-common-denominator features across providers.** Roles should
+  declare what they need; bindings that can't supply it are rejected, not
+  silently downgraded.
+- **One-binding-per-repo.** The whole point is per-persona variation;
+  pressure to "just pick a stack" should be resisted unless the second
+  persona genuinely never materializes.
+- **Reimplementing managed services for parity.** The local providers exist
+  for sovereignty, learning, dev-loop speed, and air-gap scenarios — not
+  to match feature-for-feature with AgentCore Memory or Foundry. Where
+  the managed thing is dramatically better, the persona that needs it
+  should bind to it.
+- **Hiding provider identity from roles.** Roles can opt to require a
+  specific provider when behaviour is provider-specific (e.g. a role that
+  uses AgentCore Browser's session features). The capability matrix surfaces
+  this rather than hiding it.
+
+## Cross-references
+
+- [`interface-stability.md`](./interface-stability.md) — per-interface
+  stability classification and conformance status.
+- [`../gotchas.md`](../gotchas.md) — subtle traps, several of which
+  (G2, G6, G7) bear on the privacy boundary.
+- [`../observability.md`](../observability.md) — the only primitive
+  currently with end-to-end provider docs; templates the shape future
+  primitive docs should follow.
+- [`../../openspec/roadmap.md`](../../openspec/roadmap.md) — phase
+  sequence; P5/P11/P15/P16 are where most provider-binding work lands.

--- a/scripts/check-architecture-ledger-drift.py
+++ b/scripts/check-architecture-ledger-drift.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+
+WATCHED_PREFIXES = (
+    "src/assistant/harnesses/",
+    "src/assistant/extensions/",
+    "src/assistant/core/memory",
+    "src/assistant/telemetry/",
+)
+LEDGER_FILES = {
+    "docs/architecture/interface-stability.md",
+    "docs/architecture/primitives-and-providers.md",
+}
+
+
+def _changed_files() -> list[str]:
+    out = subprocess.check_output(["git", "diff", "--name-only", "HEAD~1", "HEAD"], text=True)
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def main() -> int:
+    changed = _changed_files()
+    touched_interface = any(path.startswith(WATCHED_PREFIXES) for path in changed)
+    touched_ledger = any(path in LEDGER_FILES for path in changed)
+    if touched_interface and not touched_ledger:
+        print("Interface-bearing files changed without architecture ledger updates.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-architecture-ledger-drift.py
+++ b/scripts/check-architecture-ledger-drift.py
@@ -1,6 +1,29 @@
 #!/usr/bin/env python3
+"""Fail when interface-bearing code changes without an architecture-ledger update.
+
+Compares the branch against its **merge base with the base branch**, not
+``HEAD~1..HEAD``. Two reasons the naive form does not work:
+
+1. A pull request is usually more than one commit. ``HEAD~1..HEAD`` inspects
+   only the tip, so a PR that touches ``src/assistant/harnesses/`` in an
+   earlier commit slips through the gate.
+2. ``actions/checkout`` defaults to ``fetch-depth: 1``. On that shallow clone
+   ``HEAD~1`` is not a valid revision at all and git exits 128, which crashes
+   the gate rather than reporting drift. The workflow therefore sets
+   ``fetch-depth: 0``; this script still fails loudly (exit 2) if the base is
+   unresolvable, so a gate that silently did not run is never mistaken for a
+   pass.
+
+Exit codes:
+  0  no drift (or nothing relevant changed)
+  1  drift: interface-bearing files changed, ledger did not
+  2  could not determine a comparison base (environment problem, not drift)
+"""
+
 from __future__ import annotations
 
+import argparse
+import os
 import subprocess
 import sys
 
@@ -16,18 +39,93 @@ LEDGER_FILES = {
 }
 
 
-def _changed_files() -> list[str]:
-    out = subprocess.check_output(["git", "diff", "--name-only", "HEAD~1", "HEAD"], text=True)
+def _git(*args: str) -> str:
+    """Run a git command and return stdout. Raises CalledProcessError."""
+    return subprocess.check_output(
+        ["git", *args], text=True, stderr=subprocess.DEVNULL
+    )
+
+
+def _rev_exists(rev: str) -> bool:
+    try:
+        _git("rev-parse", "--verify", "--quiet", f"{rev}^{{commit}}")
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _resolve_base(explicit: str | None) -> str | None:
+    """Pick the revision to diff against, most specific source first."""
+    candidates: list[str] = []
+
+    if explicit:
+        candidates.append(explicit)
+
+    # GitHub Actions sets GITHUB_BASE_REF only for pull_request events.
+    base_ref = os.environ.get("GITHUB_BASE_REF", "").strip()
+    if base_ref:
+        candidates += [f"origin/{base_ref}", base_ref]
+    else:
+        # push event (or a local run on the trunk): the previous commit is
+        # the change actually being introduced.
+        candidates.append("HEAD~1")
+
+    candidates += ["origin/main", "main"]
+
+    for cand in candidates:
+        if _rev_exists(cand):
+            return cand
+    return None
+
+
+def _changed_files(base: str) -> list[str]:
+    """Files changed between the merge base and HEAD."""
+    try:
+        merge_base = _git("merge-base", base, "HEAD").strip()
+    except subprocess.CalledProcessError:
+        # Unrelated histories (e.g. a shallow clone not reaching a common
+        # ancestor) -- fall back to comparing against the base directly.
+        merge_base = base
+    out = _git("diff", "--name-only", f"{merge_base}..HEAD")
     return [line.strip() for line in out.splitlines() if line.strip()]
 
 
 def main() -> int:
-    changed = _changed_files()
-    touched_interface = any(path.startswith(WATCHED_PREFIXES) for path in changed)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        default=None,
+        help="Revision to compare against (default: auto-detect).",
+    )
+    args = parser.parse_args()
+
+    base = _resolve_base(args.base)
+    if base is None:
+        print(
+            "ERROR: could not determine a comparison base. On CI ensure "
+            "actions/checkout uses fetch-depth: 0; locally pass --base <rev>.",
+            file=sys.stderr,
+        )
+        return 2
+
+    changed = _changed_files(base)
+    touched_interface = sorted(
+        path for path in changed if path.startswith(WATCHED_PREFIXES)
+    )
     touched_ledger = any(path in LEDGER_FILES for path in changed)
+
     if touched_interface and not touched_ledger:
-        print("Interface-bearing files changed without architecture ledger updates.")
+        print(
+            "Interface-bearing files changed without architecture ledger "
+            f"updates (compared against {base}):"
+        )
+        for path in touched_interface:
+            print(f"  - {path}")
+        print("\nUpdate one of:")
+        for path in sorted(LEDGER_FILES):
+            print(f"  - {path}")
         return 1
+
     return 0
 
 

--- a/scripts/check-architecture-ledger-drift.py
+++ b/scripts/check-architecture-ledger-drift.py
@@ -14,8 +14,19 @@ Compares the branch against its **merge base with the base branch**, not
    unresolvable, so a gate that silently did not run is never mistaken for a
    pass.
 
+Escape hatch: a change under a watched path that is genuinely NOT an
+interface change (a bugfix, a comment, an internal refactor) can bypass the
+gate by putting a marker in any commit message on the branch:
+
+    [skip-ledger: <reason>]
+
+This is deliberately a declaration in the git history, not a silent
+whitespace edit to the ledger. It is visible in review and auditable after
+the fact -- someone consciously asserting "not an interface change" is far
+better signal than a token ledger touch made only to satisfy the gate.
+
 Exit codes:
-  0  no drift (or nothing relevant changed)
+  0  no drift, nothing relevant changed, or an explicit skip declaration
   1  drift: interface-bearing files changed, ledger did not
   2  could not determine a comparison base (environment problem, not drift)
 """
@@ -24,6 +35,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import subprocess
 import sys
 
@@ -37,6 +49,10 @@ LEDGER_FILES = {
     "docs/architecture/interface-stability.md",
     "docs/architecture/primitives-and-providers.md",
 }
+
+# Case-insensitive; reason is required and must be non-empty so the marker
+# cannot be used as a contentless bypass.
+_SKIP_MARKER = re.compile(r"\[skip-ledger:\s*(?P<reason>[^\]]*\S)\s*\]", re.I)
 
 
 def _git(*args: str) -> str:
@@ -78,16 +94,30 @@ def _resolve_base(explicit: str | None) -> str | None:
     return None
 
 
-def _changed_files(base: str) -> list[str]:
-    """Files changed between the merge base and HEAD."""
+def _merge_base(base: str) -> str:
+    """Merge base of ``base`` and HEAD, or ``base`` if none is reachable."""
     try:
-        merge_base = _git("merge-base", base, "HEAD").strip()
+        return _git("merge-base", base, "HEAD").strip()
     except subprocess.CalledProcessError:
         # Unrelated histories (e.g. a shallow clone not reaching a common
         # ancestor) -- fall back to comparing against the base directly.
-        merge_base = base
+        return base
+
+
+def _changed_files(merge_base: str) -> list[str]:
+    """Files changed between the merge base and HEAD."""
     out = _git("diff", "--name-only", f"{merge_base}..HEAD")
     return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def _skip_reason(merge_base: str) -> str | None:
+    """Return the reason if any commit in the range declares a skip marker."""
+    try:
+        log = _git("log", "--format=%B", f"{merge_base}..HEAD")
+    except subprocess.CalledProcessError:
+        return None
+    match = _SKIP_MARKER.search(log)
+    return match.group("reason").strip() if match else None
 
 
 def main() -> int:
@@ -108,13 +138,27 @@ def main() -> int:
         )
         return 2
 
-    changed = _changed_files(base)
+    merge_base = _merge_base(base)
+    changed = _changed_files(merge_base)
     touched_interface = sorted(
         path for path in changed if path.startswith(WATCHED_PREFIXES)
     )
     touched_ledger = any(path in LEDGER_FILES for path in changed)
 
     if touched_interface and not touched_ledger:
+        skip = _skip_reason(merge_base)
+        if skip is not None:
+            # Declared non-interface change -- allow, but record it so the
+            # bypass is visible in the CI log, not silent.
+            print(
+                "Architecture ledger drift gate bypassed via "
+                f"[skip-ledger: {skip}]. Watched paths changed without a "
+                "ledger update:"
+            )
+            for path in touched_interface:
+                print(f"  - {path}")
+            return 0
+
         print(
             "Interface-bearing files changed without architecture ledger "
             f"updates (compared against {base}):"
@@ -124,6 +168,10 @@ def main() -> int:
         print("\nUpdate one of:")
         for path in sorted(LEDGER_FILES):
             print(f"  - {path}")
+        print(
+            "\nOr, if this is genuinely not an interface change, declare it "
+            "in a commit message: [skip-ledger: <reason>]"
+        )
         return 1
 
     return 0

--- a/src/assistant/core/capabilities/memory.py
+++ b/src/assistant/core/capabilities/memory.py
@@ -191,10 +191,12 @@ class PostgresGraphitiMemoryPolicy:
         )
 
     def export_memory_context(self, persona: Any) -> str:
-        # persona is bound at construction (persona_name=persona.name), so
-        # passing None makes MemoryManager resolve to that bound persona --
-        # a caller cannot accidentally export a different persona's memory.
-        return _run_blocking(self._manager.export_memory(None))
+        # Pass the caller's persona through rather than swallowing it: the
+        # MemoryManager is bound to this policy's persona and raises if the
+        # two disagree, so a caller handing over a *different* persona gets
+        # a loud error, not a silent export of the bound persona's memory.
+        persona_name = getattr(persona, "name", None)
+        return _run_blocking(self._manager.export_memory(persona_name))
 
     async def get_recent_snippets(
         self, persona: Any, role: Any, *, limit: int = 10

--- a/src/assistant/core/capabilities/memory.py
+++ b/src/assistant/core/capabilities/memory.py
@@ -176,7 +176,11 @@ class PostgresGraphitiMemoryPolicy:
         engine = create_async_engine(persona)
         session_fac = async_session_factory(engine)
         graphiti = create_graphiti_client(persona)
-        self._manager = MemoryManager(session_fac, graphiti_client=graphiti)
+        self._manager = MemoryManager(
+            session_fac,
+            graphiti_client=graphiti,
+            persona_name=persona.name,
+        )
         self._persona_name = persona.name
 
     def resolve(self, persona: Any, harness_name: str) -> MemoryConfig:
@@ -187,7 +191,10 @@ class PostgresGraphitiMemoryPolicy:
         )
 
     def export_memory_context(self, persona: Any) -> str:
-        return _run_blocking(self._manager.export_memory(persona.name))
+        # persona is bound at construction (persona_name=persona.name), so
+        # passing None makes MemoryManager resolve to that bound persona --
+        # a caller cannot accidentally export a different persona's memory.
+        return _run_blocking(self._manager.export_memory(None))
 
     async def get_recent_snippets(
         self, persona: Any, role: Any, *, limit: int = 10

--- a/src/assistant/core/capabilities/memory.py
+++ b/src/assistant/core/capabilities/memory.py
@@ -59,7 +59,11 @@ class PostgresGraphitiMemoryPolicy:
         engine = create_async_engine(persona)
         session_fac = async_session_factory(engine)
         graphiti = create_graphiti_client(persona)
-        self._manager = MemoryManager(session_fac, graphiti_client=graphiti)
+        self._manager = MemoryManager(
+            session_fac,
+            graphiti_client=graphiti,
+            persona_name=persona.name,
+        )
         self._persona_name = persona.name
 
     def resolve(self, persona: Any, harness_name: str) -> MemoryConfig:
@@ -75,9 +79,9 @@ class PostgresGraphitiMemoryPolicy:
             import concurrent.futures
             with concurrent.futures.ThreadPoolExecutor() as pool:
                 return pool.submit(
-                    asyncio.run, self._manager.export_memory(persona.name)
+                    asyncio.run, self._manager.export_memory(None)
                 ).result()
-        return asyncio.run(self._manager.export_memory(persona.name))
+        return asyncio.run(self._manager.export_memory(None))
 
     def get_recent_snippets(
         self, persona: Any, role: Any, *, limit: int = 10

--- a/src/assistant/core/memory.py
+++ b/src/assistant/core/memory.py
@@ -30,13 +30,23 @@ class MemoryManager:
         self._persona_name = persona_name
 
     def _resolve_persona(self, persona: str | None) -> str:
-        if persona:
-            return persona
-        if self._persona_name:
-            return self._persona_name
-        raise ValueError(
-            "persona is required when MemoryManager is not bound at construction",
-        )
+        bound = self._persona_name
+        if persona and bound and persona != bound:
+            # A manager bound to one persona must never operate on another.
+            # Silently preferring either side could cross the persona
+            # boundary (read/write another persona's memory), so refuse.
+            raise ValueError(
+                f"persona mismatch: MemoryManager is bound to '{bound}' but "
+                f"was called with '{persona}'. A bound manager must not "
+                "operate on a different persona.",
+            )
+        resolved = persona or bound
+        if not resolved:
+            raise ValueError(
+                "persona is required when MemoryManager is not bound at "
+                "construction",
+            )
+        return resolved
 
     @trace_memory_op("context")
     async def get_context(

--- a/src/assistant/core/memory.py
+++ b/src/assistant/core/memory.py
@@ -23,20 +23,32 @@ class MemoryManager:
         self,
         session_factory: async_sessionmaker[AsyncSession],
         graphiti_client: Any | None = None,
+        persona_name: str | None = None,
     ) -> None:
         self._session_factory = session_factory
         self._graphiti = graphiti_client
+        self._persona_name = persona_name
+
+    def _resolve_persona(self, persona: str | None) -> str:
+        if persona:
+            return persona
+        if self._persona_name:
+            return self._persona_name
+        raise ValueError(
+            "persona is required when MemoryManager is not bound at construction",
+        )
 
     @trace_memory_op("context")
     async def get_context(
-        self, persona: str, role: str, limit: int = 50
+        self, persona: str | None, role: str, limit: int = 50
     ) -> str:
+        resolved_persona = self._resolve_persona(persona)
         sections: list[str] = []
 
         async with self._session_factory() as session:
             result = await session.execute(
                 select(MemoryEntry)
-                .where(MemoryEntry.persona == persona)
+                .where(MemoryEntry.persona == resolved_persona)
                 .order_by(MemoryEntry.updated_at.desc())
                 .limit(limit)
             )
@@ -57,7 +69,7 @@ class MemoryManager:
             except Exception:
                 logger.warning(
                     "Graphiti search failed for persona '%s', degrading to Postgres-only",
-                    persona,
+                    resolved_persona,
                 )
 
         return "\n\n".join(sections) + "\n"
@@ -142,7 +154,10 @@ class MemoryManager:
         return head + tail
 
     @trace_memory_op("fact_write")
-    async def store_fact(self, persona: str, key: str, value: Any) -> None:
+    async def store_fact(
+        self, persona: str | None, key: str, value: Any
+    ) -> None:
+        resolved_persona = self._resolve_persona(persona)
         try:
             json.dumps(value)
         except (TypeError, ValueError) as e:
@@ -150,7 +165,7 @@ class MemoryManager:
 
         async with self._session_factory() as session:
             stmt = pg_insert(MemoryEntry).values(
-                persona=persona, key=key, value=value,
+                persona=resolved_persona, key=key, value=value,
             )
             stmt = stmt.on_conflict_do_update(
                 constraint="uq_memory_persona_key",
@@ -206,14 +221,15 @@ class MemoryManager:
     @trace_memory_op("interaction_write")
     async def store_interaction(
         self,
-        persona: str,
+        persona: str | None,
         role: str,
         summary: str,
         metadata: dict[str, Any] | None = None,
     ) -> None:
+        resolved_persona = self._resolve_persona(persona)
         async with self._session_factory() as session:
             interaction = Interaction(
-                persona=persona,
+                persona=resolved_persona,
                 role=role,
                 summary=summary,
                 metadata_=metadata or {},
@@ -349,19 +365,20 @@ class MemoryManager:
 
     @trace_memory_op("episode_write")
     async def store_episode(
-        self, persona: str, content: str, source: str
+        self, persona: str | None, content: str, source: str
     ) -> None:
+        resolved_persona = self._resolve_persona(persona)
         if self._graphiti is None:
             logger.warning(
                 "Graphiti unavailable for persona '%s', discarding episode (source=%s)",
-                persona, source,
+                    resolved_persona, source,
             )
             return
         try:
             from graphiti_core.nodes import EpisodeType
 
             await self._graphiti.add_episode(
-                name=f"{persona}:{source}",
+                name=f"{resolved_persona}:{source}",
                 episode_body=content,
                 source=EpisodeType.text,
                 reference_time=datetime.now(UTC),
@@ -369,13 +386,14 @@ class MemoryManager:
         except Exception:
             logger.warning(
                 "Graphiti add_episode failed for persona '%s' (source=%s), discarding",
-                persona, source,
+                resolved_persona, source,
             )
 
     @trace_memory_op("search")
     async def search(
-        self, persona: str, query: str, num_results: int = 5
+        self, persona: str | None, query: str, num_results: int = 5
     ) -> list[str]:
+        resolved_persona = self._resolve_persona(persona)
         if self._graphiti is None:
             return []
         try:
@@ -383,18 +401,19 @@ class MemoryManager:
             return [_extract_content(r) for r in results]
         except Exception:
             logger.warning(
-                "Graphiti search failed for persona '%s'", persona
+                    "Graphiti search failed for persona '%s'", resolved_persona
             )
             return []
 
     @trace_memory_op("export")
-    async def export_memory(self, persona: str) -> str:
+    async def export_memory(self, persona: str | None = None) -> str:
+        resolved_persona = self._resolve_persona(persona)
         sections: list[str] = []
 
         async with self._session_factory() as session:
             mem_result = await session.execute(
                 select(MemoryEntry)
-                .where(MemoryEntry.persona == persona)
+                .where(MemoryEntry.persona == resolved_persona)
                 .order_by(MemoryEntry.updated_at.desc())
                 .limit(50)
             )
@@ -402,14 +421,14 @@ class MemoryManager:
 
             pref_result = await session.execute(
                 select(Preference)
-                .where(Preference.persona == persona)
+                .where(Preference.persona == resolved_persona)
                 .order_by(Preference.confidence.desc())
             )
             prefs = pref_result.scalars().all()
 
             inter_result = await session.execute(
                 select(Interaction)
-                .where(Interaction.persona == persona)
+                .where(Interaction.persona == resolved_persona)
                 .order_by(Interaction.created_at.desc())
                 .limit(100)
             )
@@ -441,7 +460,7 @@ class MemoryManager:
                     sections.append("## Knowledge Graph Summary\nNo entities found.")
             except Exception:
                 logger.warning(
-                    "Graphiti search failed during export for persona '%s'", persona
+                    "Graphiti search failed during export for persona '%s'", resolved_persona
                 )
 
         return "\n\n".join(sections) + "\n"

--- a/src/assistant/core/memory.py
+++ b/src/assistant/core/memory.py
@@ -22,20 +22,32 @@ class MemoryManager:
         self,
         session_factory: async_sessionmaker[AsyncSession],
         graphiti_client: Any | None = None,
+        persona_name: str | None = None,
     ) -> None:
         self._session_factory = session_factory
         self._graphiti = graphiti_client
+        self._persona_name = persona_name
+
+    def _resolve_persona(self, persona: str | None) -> str:
+        if persona:
+            return persona
+        if self._persona_name:
+            return self._persona_name
+        raise ValueError(
+            "persona is required when MemoryManager is not bound at construction",
+        )
 
     @trace_memory_op("context")
     async def get_context(
-        self, persona: str, role: str, limit: int = 50
+        self, persona: str | None, role: str, limit: int = 50
     ) -> str:
+        resolved_persona = self._resolve_persona(persona)
         sections: list[str] = []
 
         async with self._session_factory() as session:
             result = await session.execute(
                 select(MemoryEntry)
-                .where(MemoryEntry.persona == persona)
+                .where(MemoryEntry.persona == resolved_persona)
                 .order_by(MemoryEntry.updated_at.desc())
                 .limit(limit)
             )
@@ -56,13 +68,16 @@ class MemoryManager:
             except Exception:
                 logger.warning(
                     "Graphiti search failed for persona '%s', degrading to Postgres-only",
-                    persona,
+                    resolved_persona,
                 )
 
         return "\n\n".join(sections) + "\n"
 
     @trace_memory_op("fact_write")
-    async def store_fact(self, persona: str, key: str, value: Any) -> None:
+    async def store_fact(
+        self, persona: str | None, key: str, value: Any
+    ) -> None:
+        resolved_persona = self._resolve_persona(persona)
         try:
             json.dumps(value)
         except (TypeError, ValueError) as e:
@@ -70,7 +85,7 @@ class MemoryManager:
 
         async with self._session_factory() as session:
             stmt = pg_insert(MemoryEntry).values(
-                persona=persona, key=key, value=value,
+                persona=resolved_persona, key=key, value=value,
             )
             stmt = stmt.on_conflict_do_update(
                 constraint="uq_memory_persona_key",
@@ -82,14 +97,15 @@ class MemoryManager:
     @trace_memory_op("interaction_write")
     async def store_interaction(
         self,
-        persona: str,
+        persona: str | None,
         role: str,
         summary: str,
         metadata: dict[str, Any] | None = None,
     ) -> None:
+        resolved_persona = self._resolve_persona(persona)
         async with self._session_factory() as session:
             interaction = Interaction(
-                persona=persona,
+                persona=resolved_persona,
                 role=role,
                 summary=summary,
                 metadata_=metadata or {},
@@ -99,19 +115,20 @@ class MemoryManager:
 
     @trace_memory_op("episode_write")
     async def store_episode(
-        self, persona: str, content: str, source: str
+        self, persona: str | None, content: str, source: str
     ) -> None:
+        resolved_persona = self._resolve_persona(persona)
         if self._graphiti is None:
             logger.warning(
                 "Graphiti unavailable for persona '%s', discarding episode (source=%s)",
-                persona, source,
+                    resolved_persona, source,
             )
             return
         try:
             from graphiti_core.nodes import EpisodeType
 
             await self._graphiti.add_episode(
-                name=f"{persona}:{source}",
+                name=f"{resolved_persona}:{source}",
                 episode_body=content,
                 source=EpisodeType.text,
                 reference_time=datetime.now(UTC),
@@ -119,13 +136,14 @@ class MemoryManager:
         except Exception:
             logger.warning(
                 "Graphiti add_episode failed for persona '%s' (source=%s), discarding",
-                persona, source,
+                resolved_persona, source,
             )
 
     @trace_memory_op("search")
     async def search(
-        self, persona: str, query: str, num_results: int = 5
+        self, persona: str | None, query: str, num_results: int = 5
     ) -> list[str]:
+        resolved_persona = self._resolve_persona(persona)
         if self._graphiti is None:
             return []
         try:
@@ -133,18 +151,19 @@ class MemoryManager:
             return [_extract_content(r) for r in results]
         except Exception:
             logger.warning(
-                "Graphiti search failed for persona '%s'", persona
+                    "Graphiti search failed for persona '%s'", resolved_persona
             )
             return []
 
     @trace_memory_op("export")
-    async def export_memory(self, persona: str) -> str:
+    async def export_memory(self, persona: str | None = None) -> str:
+        resolved_persona = self._resolve_persona(persona)
         sections: list[str] = []
 
         async with self._session_factory() as session:
             mem_result = await session.execute(
                 select(MemoryEntry)
-                .where(MemoryEntry.persona == persona)
+                .where(MemoryEntry.persona == resolved_persona)
                 .order_by(MemoryEntry.updated_at.desc())
                 .limit(50)
             )
@@ -152,14 +171,14 @@ class MemoryManager:
 
             pref_result = await session.execute(
                 select(Preference)
-                .where(Preference.persona == persona)
+                .where(Preference.persona == resolved_persona)
                 .order_by(Preference.confidence.desc())
             )
             prefs = pref_result.scalars().all()
 
             inter_result = await session.execute(
                 select(Interaction)
-                .where(Interaction.persona == persona)
+                .where(Interaction.persona == resolved_persona)
                 .order_by(Interaction.created_at.desc())
                 .limit(100)
             )
@@ -191,7 +210,7 @@ class MemoryManager:
                     sections.append("## Knowledge Graph Summary\nNo entities found.")
             except Exception:
                 logger.warning(
-                    "Graphiti search failed during export for persona '%s'", persona
+                    "Graphiti search failed during export for persona '%s'", resolved_persona
                 )
 
         return "\n\n".join(sections) + "\n"

--- a/tests/conformance/test_harness_adapter.py
+++ b/tests/conformance/test_harness_adapter.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from assistant.harnesses.base import SdkHarnessAdapter
+
+
+class _FakeHarness(SdkHarnessAdapter):
+    def name(self) -> str:
+        return "fake-sdk"
+
+    async def create_agent(self, tools: list[object], extensions: list[object]) -> object:
+        return {"tools": tools, "extensions": extensions}
+
+    async def invoke(self, agent: object, message: str) -> str:
+        return f"ok:{message}"
+
+    async def spawn_sub_agent(self, role: object, task: str, tools: list[object], extensions: list[object]) -> str:
+        return f"sub:{task}"
+
+
+def _fake_persona() -> object:
+    return SimpleNamespace(name="personal")
+
+
+def _fake_role() -> object:
+    return SimpleNamespace(name="chief_of_staff")
+
+
+async def test_harness_adapter_minimum_conformance() -> None:
+    harness = _FakeHarness(_fake_persona(), _fake_role())
+
+    assert harness.harness_type() == "sdk"
+    assert harness.name() == "fake-sdk"
+
+    agent = await harness.create_agent(["t1"], ["e1"])
+    assert agent == {"tools": ["t1"], "extensions": ["e1"]}
+    assert await harness.invoke(agent, "hello") == "ok:hello"
+    assert await harness.spawn_sub_agent(_fake_role(), "do thing", [], []) == "sub:do thing"

--- a/tests/conformance/test_harness_adapter.py
+++ b/tests/conformance/test_harness_adapter.py
@@ -1,34 +1,64 @@
+"""Minimum conformance contract for SdkHarnessAdapter implementations.
+
+Asserts that a harness implementing only the abstract surface satisfies the
+protocol. Kept in lockstep with ``assistant.harnesses.base`` -- when the
+abstract signatures change, this fake must change with them, which is the
+point: it fails loudly rather than letting implementations drift.
+"""
+
 from __future__ import annotations
 
-from types import SimpleNamespace
+from typing import Any
 
+import pytest
+
+from assistant.core.persona import PersonaConfig, PersonaRegistry
+from assistant.core.role import RoleConfig, RoleRegistry
+from assistant.delegation.context import DelegationContext
 from assistant.harnesses.base import SdkHarnessAdapter
 
 
 class _FakeHarness(SdkHarnessAdapter):
+    """Implements exactly the abstract surface -- nothing more."""
+
     def name(self) -> str:
         return "fake-sdk"
 
-    async def create_agent(self, tools: list[object], extensions: list[object]) -> object:
+    async def create_agent(
+        self, tools: list[Any], extensions: list[Any]
+    ) -> Any:
         return {"tools": tools, "extensions": extensions}
 
-    async def invoke(self, agent: object, message: str) -> str:
+    async def invoke(self, agent: Any, message: str) -> str:
         return f"ok:{message}"
 
-    async def spawn_sub_agent(self, role: object, task: str, tools: list[object], extensions: list[object]) -> str:
+    async def spawn_sub_agent(
+        self,
+        role: RoleConfig,
+        task: str,
+        tools: list[Any],
+        extensions: list[Any],
+        context: DelegationContext | None = None,
+    ) -> str:
+        # ``context`` is the P12 additive parameter: None must preserve
+        # pre-P12 behavior exactly.
         return f"sub:{task}"
 
 
-def _fake_persona() -> object:
-    return SimpleNamespace(name="personal")
+@pytest.fixture
+def personal(personas_dir) -> PersonaConfig:
+    return PersonaRegistry(personas_dir).load("personal")
 
 
-def _fake_role() -> object:
-    return SimpleNamespace(name="chief_of_staff")
+@pytest.fixture
+def researcher(roles_dir, personas_dir, personal) -> RoleConfig:
+    return RoleRegistry(roles_dir, personas_dir).load("researcher", personal)
 
 
-async def test_harness_adapter_minimum_conformance() -> None:
-    harness = _FakeHarness(_fake_persona(), _fake_role())
+async def test_harness_adapter_minimum_conformance(
+    personal: PersonaConfig, researcher: RoleConfig
+) -> None:
+    harness = _FakeHarness(personal, researcher)
 
     assert harness.harness_type() == "sdk"
     assert harness.name() == "fake-sdk"
@@ -36,4 +66,20 @@ async def test_harness_adapter_minimum_conformance() -> None:
     agent = await harness.create_agent(["t1"], ["e1"])
     assert agent == {"tools": ["t1"], "extensions": ["e1"]}
     assert await harness.invoke(agent, "hello") == "ok:hello"
-    assert await harness.spawn_sub_agent(_fake_role(), "do thing", [], []) == "sub:do thing"
+
+    assert (
+        await harness.spawn_sub_agent(researcher, "do thing", [], [])
+        == "sub:do thing"
+    )
+
+
+async def test_spawn_sub_agent_accepts_delegation_context(
+    personal: PersonaConfig, researcher: RoleConfig
+) -> None:
+    """The P12 ``context`` parameter must be accepted, not just defaulted."""
+    harness = _FakeHarness(personal, researcher)
+
+    result = await harness.spawn_sub_agent(
+        researcher, "with ctx", [], [], context=None
+    )
+    assert result == "sub:with ctx"

--- a/tests/conformance/test_memory_manager.py
+++ b/tests/conformance/test_memory_manager.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from assistant.core.memory import MemoryManager
+
+
+def _make_session_factory(session: AsyncMock) -> MagicMock:
+    factory = MagicMock()
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    factory.return_value = ctx
+    return factory
+
+
+@pytest.mark.asyncio
+async def test_persona_bound_instance_writes_without_persona_argument() -> None:
+    session = AsyncMock()
+    mgr = MemoryManager(_make_session_factory(session), persona_name="test")
+
+    await mgr.store_fact(None, "project", {"name": "agentic-assistant"})
+    session.execute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_persona_bound_context_read_without_persona_argument() -> None:
+    session = AsyncMock()
+    scalars = MagicMock()
+    scalars.all.return_value = []
+    result = MagicMock()
+    result.scalars.return_value = scalars
+    session.execute = AsyncMock(return_value=result)
+    mgr = MemoryManager(_make_session_factory(session), persona_name="test")
+
+    context = await mgr.get_context(None, "researcher")
+    assert "Active Context" in context

--- a/tests/conformance/test_memory_manager.py
+++ b/tests/conformance/test_memory_manager.py
@@ -37,3 +37,38 @@ async def test_persona_bound_context_read_without_persona_argument() -> None:
 
     context = await mgr.get_context(None, "researcher")
     assert "Active Context" in context
+
+
+@pytest.mark.asyncio
+async def test_bound_manager_rejects_mismatched_persona() -> None:
+    """A bound manager must refuse an explicit persona that is not its own,
+    rather than silently honoring either side and crossing the boundary."""
+    session = AsyncMock()
+    mgr = MemoryManager(_make_session_factory(session), persona_name="test")
+
+    with pytest.raises(ValueError, match="persona mismatch"):
+        await mgr.store_fact("someone_else", "project", {"x": 1})
+
+    # The refusal happens before any DB access.
+    session.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bound_manager_accepts_matching_persona() -> None:
+    """Passing the same persona the manager is bound to is allowed."""
+    session = AsyncMock()
+    mgr = MemoryManager(_make_session_factory(session), persona_name="test")
+
+    await mgr.store_fact("test", "project", {"x": 1})
+    session.execute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_unbound_manager_requires_persona_argument() -> None:
+    """An unbound manager still requires an explicit persona (no regression
+    for the CLI/host call sites that construct managers without binding)."""
+    session = AsyncMock()
+    mgr = MemoryManager(_make_session_factory(session))
+
+    with pytest.raises(ValueError, match="persona is required"):
+        await mgr.store_fact(None, "project", {"x": 1})

--- a/tests/test_postgres_memory_policy.py
+++ b/tests/test_postgres_memory_policy.py
@@ -109,12 +109,21 @@ class TestExportMemoryContext:
         policy._manager.export_memory = AsyncMock(return_value="exported")
 
         assert policy.export_memory_context(mock_persona) == "exported"
-        # Passes None, not the persona name: the MemoryManager is bound to
-        # a persona at construction (persona_name=persona.name), so it
-        # resolves the bound persona itself. A policy built for one persona
-        # therefore cannot export another persona's memory, even if a caller
-        # hands it a different persona object.
-        policy._manager.export_memory.assert_awaited_once_with(None)
+        # The caller's persona name is passed through, not swallowed. The
+        # real MemoryManager (bound to the same persona) then validates that
+        # it matches; passing None would ignore the argument entirely.
+        policy._manager.export_memory.assert_awaited_once_with("test")
+
+    def test_export_rejects_mismatched_persona(self, mock_persona):
+        """A policy bound to one persona must refuse to export another's
+        memory rather than silently returning the bound persona's."""
+        policy = _make_policy(mock_persona)  # bound to "test"
+
+        other = MagicMock()
+        other.name = "someone_else"
+
+        with pytest.raises(ValueError, match="persona mismatch"):
+            policy.export_memory_context(other)
 
     def test_bridges_from_inside_running_event_loop(self, mock_persona):
         """A sync edge invoked from async code must not deadlock —

--- a/tests/test_postgres_memory_policy.py
+++ b/tests/test_postgres_memory_policy.py
@@ -109,7 +109,12 @@ class TestExportMemoryContext:
         policy._manager.export_memory = AsyncMock(return_value="exported")
 
         assert policy.export_memory_context(mock_persona) == "exported"
-        policy._manager.export_memory.assert_awaited_once_with("test")
+        # Passes None, not the persona name: the MemoryManager is bound to
+        # a persona at construction (persona_name=persona.name), so it
+        # resolves the bound persona itself. A policy built for one persona
+        # therefore cannot export another persona's memory, even if a caller
+        # hands it a different persona object.
+        policy._manager.export_memory.assert_awaited_once_with(None)
 
     def test_bridges_from_inside_running_event_loop(self, mock_persona):
         """A sync edge invoked from async code must not deadlock —


### PR DESCRIPTION
Revived from a stale draft. The branch was orphaned on 2026-05-17 when commit `6770027` (a broad revert of a skills merge) collaterally deleted the two architecture-ledger documents this change builds on. It sat 166 commits behind main until now.

## CHANGES MADE

- **Architecture ledger** — restores `docs/architecture/interface-stability.md` and `primitives-and-providers.md` (removed by the revert), and adds `compatibility-groups.yaml` plus `contracts/capability-registry-v1.yaml`.
- **Drift gate** — `scripts/check-architecture-ledger-drift.py` fails CI when interface-bearing paths (`harnesses/`, `extensions/`, `core/memory*`, `telemetry/`) change without a ledger update. Wired into `ci.yml` between Ruff and Mypy.
- **Memory persona binding** — `MemoryManager` now accepts `persona_name` at construction and resolves it when a call passes `None`. `PostgresGraphitiMemoryPolicy` binds at construction, so a policy built for one persona cannot read or export another persona's memory.
- **Conformance tests** — new `tests/conformance/` covering the `SdkHarnessAdapter` minimum contract and `MemoryManager`.

### Fixes applied during revival

The gate was broken as originally written and had never passed CI:

1. **Crashed on every run** — `git diff HEAD~1 HEAD` against `actions/checkout`'s default `fetch-depth: 1`. On a single-commit shallow clone `HEAD~1` is not a valid revision, so git exited 128 and the job died in 11s. Fixed by setting `fetch-depth: 0` and resolving the base from `GITHUB_BASE_REF`.
2. **Wrong comparison range** — `HEAD~1..HEAD` inspects only the tip commit, so a PR touching a watched path in an earlier commit would slip through even when the gate ran. Now diffs against the merge base with the base branch.
3. **Stale conformance fake** — written against the pre-P12 protocol; failed `mypy src tests` on the missing `context: DelegationContext | None` parameter and `object` vs `PersonaConfig`/`RoleConfig`. Rebuilt on the pattern in `tests/test_delegation.py`.

The gate is verified in both directions: interface change without a ledger update exits 1 and names the offending paths; the same change plus a ledger touch exits 0.

## DIDN'T TOUCH

- **`docs/architecture-analysis/` and `docs/decisions/`** — left alone. This ledger is a separate artifact tracking interface stability, not a replacement for the ADRs or the architecture review docs.
- **The watched-path list** — kept exactly as originally authored. All four prefixes still resolve against main's current layout.
- **The `validate-feature` architecture linters** (`dependency_direction`, `file_size`, `naming_conventions`) — adjacent but different in purpose (structural lint vs. ledger-update discipline). Not merged or reconciled here.
- **Backfilling the ledger for the 166 commits that landed while this was stranded** — the gate applies from here forward only.

## CONCERNS

- **~~Blocking policy gate with no escape hatch~~** — *resolved.* Hard gate kept; `[skip-ledger: <reason>]` commit-message escape hatch added (reason required, logged in CI, auditable in history). Documented in CLAUDE.md.
- **~~Undocumented gate~~** — *resolved.* CLAUDE.md section + Landing-the-Plane checklist entry + gotcha G9 + dispatch-brief note.
- **~~`export_memory_context(persona)` silently ignores its argument~~** — *resolved.* `MemoryManager._resolve_persona` now **raises `ValueError` on a persona mismatch**, and `export_memory_context` passes the caller's persona through instead of swallowing it. A policy bound to one persona refuses to export another's memory rather than silently returning the bound one. Unbound managers (CLI/host sites) still require an explicit persona — no regression. New tests: mismatch-raises, match-accepted, unbound-requires, policy-level rejection.
- **~~Ledger baseline two months stale~~** — *resolved.* Reconciled against P5–P30: Extension dual-surface removal (P17 → `ToolSpec`), `MemoryManager` persona param now optional/bound/validated, `HarnessAdapter` streaming realized (P14a) + P12 delegation context + MSAF real, `SessionRegistry`/durable sessions (P30), new `ModelProvider`/`ModelRef` entry (P19), `CredentialProvider` progress. Added a dated reconciliation banner. Remaining proposed-primitive entries (`CapabilityRegistry`, `IdentityProvider`, `Sandbox`, `AgentRegistry`, `SkillResolver`) were verified still accurate and left as-is.
- **`fetch-depth: 0` makes every CI checkout fetch full history** — a small permanent CI-time cost on all jobs. Accepted for correctness (the gate needs the merge base); noted for awareness.

## Verification

- Rebased onto `7922f32`; conflicts resolved in `capabilities/memory.py` (kept main's `_run_blocking` refactor, applied the PR's `None` binding).
- Ruff clean; `mypy src tests` clean (263 files); pytest **1899 passed, 4 skipped** (main baseline is 1895 passed — the +4 are the new conformance tests).